### PR TITLE
Fixed memory leak warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ const util = require('util')
 var audioStream = fs.createReadStream('../test/samples/MusicBrainz-multiartist [id3v2.4].V2.mp3')
 
 // create a new music-metadata from a node ReadStream
-mm.parseStream(audioStream, {native: true}, function (err, metadata) {
+mm.parseStream(audioStream, {native: true}, function (err, metadata, underlayingAudioStream) {
   // important note, the stream is not closed by default. To prevent leaks, you must close it yourself
-  audioStream.close();
+  underlayingAudioStream.close();
   if (err) throw err;
 
   console.log(util.inspect(metadata, {showHidden: false, depth: null}));
@@ -60,9 +60,9 @@ import * as util from 'util'
 let audioStream = fs.createReadStream('../test/samples/MusicBrainz-multiartist [id3v2.4].V2.mp3')
 
 // create a new music-metadata parser from a node ReadStream
-mm.parseStream(audioStream, {native: true}, (err, metadata) => {
+mm.parseStream(audioStream, {native: true}, (err, metadata, underlayingAudioStream) => {
   // important note, the stream is not closed by default. To prevent leaks, you must close it yourself
-  audioStream.close();
+  underlayingAudioStream.close();
   if (err) throw err;
 
   console.log(util.inspect(metadata, {showHidden: false, depth: null}));

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,7 +365,7 @@ class MusicMetadataParser {
       }
 
       if (callback) {
-        callback(err, metadata);
+        callback(err, metadata, stream);
       }
       return strtok.DONE;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ export interface IAudioMetadata {
   format: IFormat;
 }
 
-export type ICallbackType = (error?: Error, metadata?: IAudioMetadata) => void;
+export type ICallbackType = (error?: Error, metadata?: IAudioMetadata, underlayingAudioStream?:ReadableStream) => void;
 
 export interface IOptions {
   path?: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ export interface IAudioMetadata {
   format: IFormat;
 }
 
-export type ICallbackType = (error?: Error, metadata?: IAudioMetadata, underlayingAudioStream?:ReadableStream) => void;
+export type ICallbackType = (error?: Error, metadata?: IAudioMetadata, underlayingAudioStream?: ReadableStream) => void;
 
 export interface IOptions {
   path?: string,


### PR DESCRIPTION
Sample code to reproduce warning with previous code
```

for(var file of files){ 
      var audioStream = fs.createReadStream(file) 
      // create a new music-metadata from a node ReadStream 
      mm.parseStream(audioStream, {native: true}, function (err, metadata) {
        // important note, the stream is not closed by default. To prevent leaks, you must close it yourself 
        audioStream.close()
        if (err) throw err
          console.log(util.inspect(metadata, {showHidden: false, depth: null}));
      })
    }
```