### PR TITLE
Read ogg vorbis tags as utf-8, not ascii

### DIFF
--- a/src/vorbis/VorbisParser.ts
+++ b/src/vorbis/VorbisParser.ts
@@ -104,7 +104,7 @@ export class VorbisParser implements ITokenParser {
 
   private parseUserComment(userCommentListLength: number): Promise<number> {
     return this.tokenizer.readToken<number>(Token.UINT32_LE).then(strLen => {
-      return this.tokenizer.readToken<string>(new Token.StringType(strLen, 'ascii')).then(v => {
+      return this.tokenizer.readToken<string>(new Token.StringType(strLen, 'utf-8')).then(v => {
         const idx = v.indexOf('=');
         const key = v.slice(0, idx).toUpperCase();
         let value: any = v.slice(idx + 1);


### PR DESCRIPTION
I'm not familiar with the `music-metadata` codebase, so feel free to point it out if there is a reason tags are read here as `ascii`.

Note that with any file with special characters, using `ascii` results in the special characters being removed and replaced with encodings (similar to percent encodings, but without the percent sign).

Tests still pass.