### PR TITLE
Build/travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ jobs:
       script: npm run compile
       node_js: 10
 
+    - stage: prepare cache
+      script: npm run compile
+      node_js: 10
+
     - stage: test
       script: npm run test
       node_js: 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,15 @@ jobs:
   include:
     - stage: check code
       script: npm run lint
+      node_js: 9
 
     - stage: install dependencies
       script: npm install
+      node_js: 9
 
+    - stage: compile
+      script: npm run compile
+      node_js: 7
     - stage: compile
       script: npm run compile
       node_js: 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,18 @@ jobs:
   include:
     - stage: check code
       script: npm run lint
-    - stage: test
+
+    - stage: install
+      script: npm install typescript@2.0
+      node_js: 4
+    - stage: install
+      script: npm install typescript@2.4
+      node_js: 6
+
+    - stage: script
       script: npm run lint
       script: npm run compile
       script: npm run coveralls
-    - stage: before_script
-      script: npm install typescript@2.0
-      node_js: 4
-    - stage: before_script
-      script: npm install typescript@2.4
-      node_js: 6
 
     - stage: after_success
       script: npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,51 @@ language: node_js
 
 jobs:
   include:
-    - stage: npm install
+    - stage: check code
+      script: npm run lint
+      node_js: 8
+
+    - stage: install dependencies
+      script: npm install
+    - stage: compile
+      script: npm run compile
+      node_js: 7
+
+    - stage: compile
       script: npm run compile
       node_js: 8
     - stage: compile
       script: npm run compile
-      node_js: 8
+      node_js: 9
+    - stage: compile
+      script: npm run compile
+      node_js: 10
+
     - stage: test
-      script: npm run lint
+      script: npm run test
+      node_js: 0.12
+    - stage: test
+      script: npm run test
+      node_js: 4
+    - stage: test
+      script: npm run test
+      node_js: 5
+    - stage: test
+      script: npm run test
+      node_js: 6
+    - stage: test
       script: npm run test
       node_js: 7
     - stage: test
-      script: npm run lint
       script: npm run test
       node_js: 8
     - stage: test
-      script: npm run lint
       script: npm run test
       node_js: 9
+    - stage: test
+      script: npm run test
+      node_js: 10
+
     - stage: after_success
       script: npm run coveralls
       node_js: 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,27 @@
 language: node_js
 
+node_js:
+- "4"
+- "6"
+- "7"
+- "8"
+- "9"
+- "10"
+
 jobs:
   include:
     - stage: check code
       script: npm run lint
-      node_js: 9
-
-    - stage: install dependencies
-      script: npm install
-
-    - stage: compile
+    - stage: test
+      script: npm run lint
+      script: npm run compile
+      script: npm run coveralls
+    - stage: before_script
       script: npm install typescript@2.0
-      script: npm run compile
       node_js: 4
-    - stage: compile
+    - stage: before_script
       script: npm install typescript@2.4
-      script: npm run compile
       node_js: 6
-    - stage: compile
-      script: npm run compile
-      node_js: 7
-    - stage: compile
-      script: npm run compile
-      node_js: 8
-    - stage: compile
-      script: npm run compile
-      node_js: 9
-    - stage: compile
-      script: npm run compile
-      node_js: 10
-
-    - stage: test
-      script: npm run test
-      node_js: 4
-    - stage: test
-      script: npm run test
-      node_js: 6
-    - stage: test
-      script: npm run test
-      node_js: 7
-    - stage: test
-      script: npm run test
-      node_js: 8
-    - stage: test
-      script: npm run test
-      node_js: 9
-    - stage: test
-      script: npm run test
-      node_js: 10
 
     - stage: after_success
       script: npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,25 @@
 language: node_js
-node_js:
- - "6"
- - "7"
- - "8"
- - "9"
 
 jobs:
   include:
-    - stage: install_dependencies
-      script: npm install
-    - stage: check_code
-      script: npm run lint
+    - stage: npm install
+      script: npm run compile
+      node_js: 8
     - stage: compile
       script: npm run compile
+      node_js: 8
     - stage: test
+      script: npm run lint
       script: npm run test
+      node_js: 7
+    - stage: test
+      script: npm run lint
+      script: npm run test
+      node_js: 8
+    - stage: test
+      script: npm run lint
+      script: npm run test
+      node_js: 9
     - stage: after_success
       script: npm run coveralls
       node_js: 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ jobs:
       script: npm run lint
       node_js: 9
 
+    - stage: install dependencies
+      script: npm install
+
     - stage: compile
-      script: npm install typescript@2.0
       script: npm run compile
       node_js: 4
     - stage: compile
-      script: npm install typescript@2.4
       script: npm run compile
       node_js: 6
     - stage: compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ jobs:
       script: npm install
 
     - stage: compile
-      script: npm intall typescript@2.0
+      script: npm install typescript@2.0
       script: npm run compile
       node_js: 4
     - stage: compile
-      script: npm intall typescript@2.4
+      script: npm install typescript@2.4
       script: npm run compile
       node_js: 6
     - stage: compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,21 @@
 language: node_js
 
+node_js:
+ - "4"
+ - "6"
+ - "7"
+ - "8"
+ - "9"
+ - "10"
+
+install:
+- npm install
+script:
+- npm run lint
+- npm run compile
+- npm run test
+
 jobs:
-  include:
-    - stage: check code
-      script: npm run lint
-      node_js: 9
-
-    - stage: install dependencies
-      script: npm install
-
-    - stage: compile
-      script: npm run compile
-      node_js: 4
-    - stage: compile
-      script: npm run compile
-      node_js: 6
-    - stage: compile
-      script: npm run compile
-      node_js: 7
-    - stage: compile
-      script: npm run compile
-      node_js: 8
-    - stage: compile
-      script: npm run compile
-      node_js: 9
-    - stage: compile
-      script: npm run compile
-      node_js: 10
-
-    - stage: prepare cache
-      script: npm run compile
-      node_js: 10
-
-    - stage: test
-      script: npm run test
-      node_js: 4
-    - stage: test
-      script: npm run test
-      node_js: 6
-    - stage: test
-      script: npm run test
-      node_js: 7
-    - stage: test
-      script: npm run test
-      node_js: 8
-    - stage: test
-      script: npm run test
-      node_js: 9
-    - stage: test
-      script: npm run test
-      node_js: 10
-
     - stage: after_success
       script: npm run coveralls
       node_js: 9

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,15 @@ jobs:
 
     - stage: install dependencies
       script: npm install
-      node_js: 9
 
+    - stage: compile
+      script: npm intall typescript@2.0
+      script: npm run compile
+      node_js: 4
+    - stage: compile
+      script: npm intall typescript@2.4
+      script: npm run compile
+      node_js: 6
     - stage: compile
       script: npm run compile
       node_js: 7
@@ -23,6 +30,12 @@ jobs:
       script: npm run compile
       node_js: 10
 
+    - stage: test
+      script: npm run test
+      node_js: 4
+    - stage: test
+      script: npm run test
+      node_js: 6
     - stage: test
       script: npm run test
       node_js: 7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,9 @@ jobs:
   include:
     - stage: check code
       script: npm run lint
-      node_js: 8
 
     - stage: install dependencies
       script: npm install
-    - stage: compile
-      script: npm run compile
-      node_js: 7
 
     - stage: compile
       script: npm run compile
@@ -22,18 +18,6 @@ jobs:
       script: npm run compile
       node_js: 10
 
-    - stage: test
-      script: npm run test
-      node_js: 0.12
-    - stage: test
-      script: npm run test
-      node_js: 4
-    - stage: test
-      script: npm run test
-      node_js: 5
-    - stage: test
-      script: npm run test
-      node_js: 6
     - stage: test
       script: npm run test
       node_js: 7
@@ -49,4 +33,8 @@ jobs:
 
     - stage: after_success
       script: npm run coveralls
-      node_js: 8
+      node_js: 9
+
+matrix:
+  allow_failures:
+  - node_js: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,17 @@ node_js:
  - "7"
  - "8"
  - "9"
-install:
-- npm install
-script:
-- npm run lint
-- npm run compile
-- npm run test
 
 jobs:
   include:
+    - stage: install_dependencies
+      script: npm install
+    - stage: check_code
+      script: npm run lint
+    - stage: compile
+      script: npm run compile
+    - stage: test
+      script: npm run test
     - stage: after_success
       script: npm run coveralls
       node_js: 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,50 @@
 language: node_js
 
-node_js:
-- "4"
-- "6"
-- "7"
-- "8"
-- "9"
-- "10"
-
 jobs:
   include:
     - stage: check code
       script: npm run lint
+      node_js: 9
 
-    - stage: install
+    - stage: compile
       script: npm install typescript@2.0
-      node_js: 4
-    - stage: install
-      script: npm install typescript@2.4
-      node_js: 6
-
-    - stage: script
-      script: npm run lint
       script: npm run compile
-      script: npm run coveralls
+      node_js: 4
+    - stage: compile
+      script: npm install typescript@2.4
+      script: npm run compile
+      node_js: 6
+    - stage: compile
+      script: npm run compile
+      node_js: 7
+    - stage: compile
+      script: npm run compile
+      node_js: 8
+    - stage: compile
+      script: npm run compile
+      node_js: 9
+    - stage: compile
+      script: npm run compile
+      node_js: 10
+
+    - stage: test
+      script: npm run test
+      node_js: 4
+    - stage: test
+      script: npm run test
+      node_js: 6
+    - stage: test
+      script: npm run test
+      node_js: 7
+    - stage: test
+      script: npm run test
+      node_js: 8
+    - stage: test
+      script: npm run test
+      node_js: 9
+    - stage: test
+      script: npm run test
+      node_js: 10
 
     - stage: after_success
       script: npm run coveralls

--- a/package-lock.json
+++ b/package-lock.json
@@ -713,9 +713,9 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.0.tgz",
-      "integrity": "sha512-lk2cUCo8QzbiEWEbt7Cw3m27WMiRG321xsssbcIpfMhpRjrlC08WBOVQqj1/nQYYNnPtyIhP1oqLO3QwT2tPCw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "debug": "^3.1.0",
-    "fs-extra": "^6.0.0",
+    "fs-extra": "^5.0.0",
     "strtok3": "^1.4.1",
     "then-read-stream": "^1.1.1",
     "token-types": "^0.9.3"

--- a/src/asf/Util.ts
+++ b/src/asf/Util.ts
@@ -21,8 +21,9 @@ export class Util {
     let n = buf[offset];
     let mul = 1;
     let i = 0;
-    while (++i < 8 && (mul *= 0x100)) {
-      n += buf[offset + i] * mul
+    while (++i < 8) {
+      mul *= 0x100;
+      n += buf[offset + i] * mul;
     }
     return n;
   }

--- a/test/test-apev2-monkeysaudio.ts
+++ b/test/test-apev2-monkeysaudio.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-asf.ts
+++ b/test/test-asf.ts
@@ -1,9 +1,8 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';
 import GUID from "../src/asf/GUID";
-import * as fs from 'fs-extra';
+import * as fse from 'fs-extra';
 import {Util} from "../src/asf/Util";
 import {DataType} from "../src/asf/AsfObject";
 
@@ -100,7 +99,7 @@ describe("ASF", () => {
 
     it("should decode from ASF from a stream (audio/x-ms-wma)", () => {
 
-      const stream = fs.createReadStream(asfFilePath);
+      const stream = fse.createReadStream(asfFilePath);
 
       return mm.parseStream(stream, 'audio/x-ms-wma', {native: true}).then(metadata => {
         checkFormat(metadata.format);

--- a/test/test-audio-frame-header-bug.ts
+++ b/test/test-audio-frame-header-bug.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-comment-mapping.ts
+++ b/test/test-comment-mapping.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-common.ts
+++ b/test/test-common.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from "chai";
 
 import {CommonTagMapper} from "../src/common/GenericTagMapper";

--- a/test/test-concurrent-picture.ts
+++ b/test/test-concurrent-picture.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as fs from 'fs-extra';

--- a/test/test-discogs.ts
+++ b/test/test-discogs.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from "chai";
 import * as mm from "../src";
 

--- a/test/test-flac.ts
+++ b/test/test-flac.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from "chai";
 import * as mm from "../src";
 import * as fs from "fs-extra";

--- a/test/test-id3v1.1.ts
+++ b/test/test-id3v1.1.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-id3v2-duration-allframes.ts
+++ b/test/test-id3v2-duration-allframes.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-id3v2-lyrics.ts
+++ b/test/test-id3v2-lyrics.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-id3v2-unknownframe.ts
+++ b/test/test-id3v2-unknownframe.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-id3v2-utf16encoded.ts
+++ b/test/test-id3v2-utf16encoded.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-id3v2-xheader.ts
+++ b/test/test-id3v2-xheader.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-id3v2.2.ts
+++ b/test/test-id3v2.2.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-id3v2.3.ts
+++ b/test/test-id3v2.3.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-id3v2.4-musicbrainz.ts
+++ b/test/test-id3v2.4-musicbrainz.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-id3v2.4.ts
+++ b/test/test-id3v2.4.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-m4a-ffmpeg.ts
+++ b/test/test-m4a-ffmpeg.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 
 const t = assert;

--- a/test/test-m4a.ts
+++ b/test/test-m4a.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-mime.ts
+++ b/test/test-mime.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from "chai";
 import * as mime from "mime";
 import * as mm from "../src";

--- a/test/test-mp3.ts
+++ b/test/test-mp3.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-mpeg.ts
+++ b/test/test-mpeg.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from "chai";
 import * as mm from "../src";
 

--- a/test/test-musicbrainz-picard-vorbis.ts
+++ b/test/test-musicbrainz-picard-vorbis.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-no-metadata.ts
+++ b/test/test-no-metadata.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-nonasciichars.ts
+++ b/test/test-nonasciichars.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-ogg-multipagemetadatabug.ts
+++ b/test/test-ogg-multipagemetadatabug.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-ogg.ts
+++ b/test/test-ogg.ts
@@ -1,10 +1,8 @@
-import {} from "mocha";
 import {assert, expect} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import {IdHeader} from "../src/opus/Opus";
-import {OggParser} from "../src/ogg/OggParser";
 
 describe("Parsing Ogg", function() {
 

--- a/test/test-options.ts
+++ b/test/test-options.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-picard-mappings.ts
+++ b/test/test-picard-mappings.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import {AsfTagMapper} from "../src/asf/AsfTagMapper";
 import {APEv2TagMapper} from "../src/apev2/APEv2TagMapper";

--- a/test/test-picard-parsing.ts
+++ b/test/test-picard-parsing.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';

--- a/test/test-regress-GH-56.ts
+++ b/test/test-regress-GH-56.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from "chai";
 import * as mm from "../src";
 import * as fs from "fs-extra";

--- a/test/test-replaygain.ts
+++ b/test/test-replaygain.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from "chai";
 import * as mm from "../src";
 

--- a/test/test-ufid.ts
+++ b/test/test-ufid.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-unknownencoding.ts
+++ b/test/test-unknownencoding.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-utf16bom-encoding.ts
+++ b/test/test-utf16bom-encoding.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import util from "../src/common/Util";
 import {FourCcToken} from "../src/common/FourCC";

--- a/test/test_riff.ts
+++ b/test/test_riff.ts
@@ -1,4 +1,3 @@
-import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as path from 'path';


### PR DESCRIPTION
Add workaround to travis-ci build script, so that compatibility is tested against Node v4. Issue is that latest typescript is not compatible with Node v4. 