### PR TITLE
fix: cannot read property '0' of undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -418,7 +418,7 @@ export class MusicMetadataParser {
     }
 
     if (metadata.common.artists && metadata.common.artists.length > 0) {
-      metadata.common.artist = metadata.common.artist[0];
+      metadata.common.artist = metadata.common.artists[0];
     } else {
       if (metadata.common.artist) {
         metadata.common.artists = metadata.common.artist as any;


### PR DESCRIPTION
failure when parsing .wma files