### PR TITLE
Fix parseStream function & add 'audio/mp3' mime-type

### DIFF
--- a/src/ParserFactory.ts
+++ b/src/ParserFactory.ts
@@ -63,12 +63,13 @@ export class ParserFactory {
 
       // Interpret mimeType as extension
       const parser = ParserFactory.getParserForMimeType(mimeType) || ParserFactory.getParserForExtension(mimeType) as ITokenParser;
-      if (parser === null) {
+      if (parser) {
+        // Parser found, execute parser
+        return parser.parse(tokenizer, opts);
+      } else {
         // No MIME-type mapping found
         throw new Error("MIME-type or extension not supported:" + mimeType);
       }
-      // Parser found, execute parser
-      return parser.parse(tokenizer, opts);
     });
   }
 

--- a/src/ParserFactory.ts
+++ b/src/ParserFactory.ts
@@ -140,6 +140,7 @@ export class ParserFactory {
     switch (mimeType) {
 
       case "audio/mpeg":
+      case "audio/mp3":
         return new MpegParser(); // ToDo: handle ID1 header as well
 
       case "audio/x-monkeys-audio":


### PR DESCRIPTION
Function `parseStream` throws TypeError exception when there is no suitable mime-type (in my case that was 'audio/mp3') due to the `getParserForMimeType` function returning boolean value instead of null.

```
TypeError: parser.parse is not a function
    at node_modules/music-metadata/lib/ParserFactory.js:67:27
```