### PR TITLE
Replace bluebird with es6-promise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
- - "4"
  - "6"
  - "7"
  - "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+ - "4"
  - "6"
  - "7"
  - "8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,6 +164,15 @@
       "integrity": "sha512-h6+VEw2Vr3ORiFCyyJmcho2zALnUq9cvdB/IO8Xs9itrJVCenC7o26A6+m7D0ihTTr65eS259H5/Ghl/VjYs6g==",
       "dev": true
     },
+    "@types/es6-promise": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
+      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.2.4"
+      }
+    },
     "@types/file-type": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/@types/file-type/-/file-type-5.2.1.tgz",
@@ -335,11 +344,6 @@
       "requires": {
         "tweetnacl": "0.14.5"
       }
-    },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "boom": {
       "version": "4.3.1",
@@ -771,6 +775,11 @@
         "is-symbol": "1.0.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -881,14 +890,14 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "universalify": "0.1.2"
       }
     },
     "fs.realpath": {
@@ -3367,13 +3376,13 @@
       "dev": true
     },
     "strtok3": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-1.4.4.tgz",
-      "integrity": "sha512-p8CkUYODTJ8aGx+WyAXDvDoUj112EHAE7h2jtsHJW8yC5NrxLKKA5W5R8t9HDpPC6FYP/FlaFT0hS/XhdQvOFQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-1.5.0.tgz",
+      "integrity": "sha512-IV4MZ04EckyaDitPAXjD3q2jB+v+N6RqAAk3iB1yY7FesWI468PzAmM9po2bs5BNG6wpMbrtj2uKBnTRZsrNFw==",
       "requires": {
-        "bluebird": "3.5.1",
         "coveralls": "3.0.1",
-        "then-read-stream": "1.1.3",
+        "es6-promise": "4.2.4",
+        "then-read-stream": "1.2.0",
         "token-types": "0.9.4"
       }
     },
@@ -3393,11 +3402,11 @@
       }
     },
     "then-read-stream": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-1.1.3.tgz",
-      "integrity": "sha512-v49Z6JnjtMS/+Vxee4EHl+ho7StqAKFhYciAZEDz7Dvi5/A97dtcu1wRdvLf+xxvo9wqrfz+MNRnJmsu0o7raQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-1.2.0.tgz",
+      "integrity": "sha512-AvgNVPIpm7zrMcAk+LP1zUy4A006V1uKYKvlrdxQPUb4FgfGh68Ke/JE+zog/OcFs9yo6a6MKjgEvS+hNSOVPQ==",
       "requires": {
-        "bluebird": "3.5.1"
+        "es6-promise": "4.2.4"
       }
     },
     "through": {
@@ -3573,9 +3582,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unzip-response": {

--- a/package.json
+++ b/package.json
@@ -63,15 +63,16 @@
     "doc-gen": "node doc-gen/gen.js"
   },
   "dependencies": {
-    "bluebird": "^3.5.1",
     "debug": "^3.1.0",
+    "es6-promise": "^4.2.4",
     "file-type": "^8.0.0",
-    "strtok3": "^1.4.4",
-    "then-read-stream": "^1.1.3",
+    "strtok3": "^1.5.0",
+    "then-read-stream": "^1.2.0",
     "token-types": "^0.9.4"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",
+    "@types/es6-promise": "^3.3.0",
     "@types/file-type": "^5.2.1",
     "@types/fs-extra": "^5.0.3",
     "@types/mocha": "^5.2.3",
@@ -79,7 +80,7 @@
     "chai": "^4.1.2",
     "coveralls": "^3.0.1",
     "del-cli": "^1.1.0",
-    "fs-extra": "^6.0.1",
+    "fs-extra": "^5.0.0",
     "mime": "^2.3.1",
     "mocha": "^5.2.0",
     "npm-run-all": "^4.1.3",

--- a/src/ParserFactory.ts
+++ b/src/ParserFactory.ts
@@ -5,7 +5,7 @@ import {FlacParser} from "./flac/FlacParser";
 import {MP4Parser} from "./mp4/MP4Parser";
 import {OggParser} from "./ogg/OggParser";
 import * as strtok3 from "strtok3";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 import * as Stream from "stream";
 import * as path from "path";
 import {AIFFParser} from "./aiff/AiffParser";

--- a/src/aiff/AiffParser.ts
+++ b/src/aiff/AiffParser.ts
@@ -6,6 +6,7 @@ import * as Chunk from "./Chunk";
 import {Readable} from "stream";
 import {ID3v2Parser} from "../id3v2/ID3v2Parser";
 import {FourCcToken} from "../common/FourCC";
+import {Promise} from "es6-promise";
 
 /**
  * AIFF - Audio Interchange File Format

--- a/src/apev2/APEv2Parser.ts
+++ b/src/apev2/APEv2Parser.ts
@@ -7,7 +7,7 @@ import {ITokenParser} from "../ParserFactory";
 import {ITokenizer, IgnoreType} from "strtok3";
 import * as Token from "token-types";
 import {FourCcToken} from "../common/FourCC";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 import FileType = require("file-type");
 
 import * as _debug from "debug";

--- a/src/asf/AsfParser.ts
+++ b/src/asf/AsfParser.ts
@@ -5,7 +5,7 @@ import {ITokenizer} from "strtok3";
 import {ITokenParser} from "../ParserFactory";
 import GUID from "./GUID";
 import * as AsfObject from "./AsfObject";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 import * as _debug from "debug";
 
 const debug = _debug("music-metadata:parser:ASF");

--- a/src/flac/FlacParser.ts
+++ b/src/flac/FlacParser.ts
@@ -7,7 +7,7 @@ import * as Token from "token-types";
 import {IVorbisPicture, VorbisPictureToken} from "../vorbis/Vorbis";
 import {AbstractID3v2Parser} from "../id3v2/AbstractID3Parser";
 import {FourCcToken} from "../common/FourCC";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 
 /**
  * FLAC supports up to 128 kinds of metadata blocks; currently the following are defined:

--- a/src/id3v2/AbstractID3Parser.ts
+++ b/src/id3v2/AbstractID3Parser.ts
@@ -4,7 +4,7 @@ import {INativeAudioMetadata, IOptions} from "../index";
 import {ID3v2Token} from "./ID3v2";
 import {ID3v2Parser} from "./ID3v2Parser";
 import {ID3v1Parser} from "../id3v1/ID3v1Parser";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 
 import * as _debug from "debug";
 

--- a/src/mp4/MP4Parser.ts
+++ b/src/mp4/MP4Parser.ts
@@ -1,7 +1,7 @@
 import {ITokenParser} from "../ParserFactory";
 import {INativeAudioMetadata, ITag, IFormat, IOptions} from "../";
 import {ITokenizer} from "strtok3";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 import * as Token from "token-types";
 import * as Atom from "./Atom";
 import {Genres} from "../id3v1/ID3v1Parser";

--- a/src/mpeg/MpegParser.ts
+++ b/src/mpeg/MpegParser.ts
@@ -5,7 +5,7 @@ import * as Token from "token-types";
 import {AbstractID3v2Parser} from "../id3v2/AbstractID3Parser";
 import {INativeAudioMetadata, IOptions} from "../index";
 import {InfoTagHeaderTag, IXingInfoTag, LameEncoderVersion, XingInfoTag} from "./XingTag";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 
 import * as _debug from "debug";
 const debug = _debug("music-metadata:parser:mpeg");

--- a/src/ogg/OggParser.ts
+++ b/src/ogg/OggParser.ts
@@ -3,7 +3,7 @@ import common from "../common/Util";
 import {ITokenParser} from "../ParserFactory";
 import * as strtok3 from "strtok3";
 import {INativeAudioMetadata, IOptions} from "../index";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 import {VorbisParser} from "../vorbis/VorbisParser";
 import {FourCcToken} from "../common/FourCC";
 import * as Ogg from "./Ogg";

--- a/src/riff/RiffParser.ts
+++ b/src/riff/RiffParser.ts
@@ -9,7 +9,7 @@ import {ID3v2Parser} from "../id3v2/ID3v2Parser";
 import {IChunkHeader} from "../aiff/Chunk";
 import Common from "../common/Util";
 import {FourCcToken} from "../common/FourCC";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 import * as _debug from "debug";
 
 const debug = _debug("music-metadata:parser:RIFF");

--- a/src/vorbis/VorbisParser.ts
+++ b/src/vorbis/VorbisParser.ts
@@ -1,7 +1,7 @@
 'use strict';
 import * as Vorbis from './Vorbis';
 import {IFormat, INativeAudioMetadata, IOptions, ITag} from "../index";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 import * as Token from "token-types";
 import * as Ogg from "../ogg/Ogg";
 import * as _debug from "debug";

--- a/src/wavpack/WavPackParser.ts
+++ b/src/wavpack/WavPackParser.ts
@@ -4,7 +4,7 @@ import {ITokenizer} from "strtok3";
 import * as Token from "token-types";
 import {APEv2Parser} from "../apev2/APEv2Parser";
 import {FourCcToken} from "../common/FourCC";
-import {Promise} from "bluebird";
+import {Promise} from "es6-promise";
 
 /**
  * WavPack Block Header

--- a/test/test-concurrent-picture.ts
+++ b/test/test-concurrent-picture.ts
@@ -2,7 +2,7 @@ import {} from "mocha";
 import {assert} from 'chai';
 import * as mm from '../src';
 import * as fs from 'fs-extra';
-import {Promise} from 'bluebird';
+import {Promise} from 'es6-promise';
 import * as path from 'path';
 
 const t = assert;

--- a/test/test-mime.ts
+++ b/test/test-mime.ts
@@ -3,7 +3,7 @@ import {assert} from "chai";
 import * as mime from "mime";
 import * as mm from "../src";
 import {SourceStream} from "./util";
-import {Promise} from 'bluebird';
+import {Promise} from 'es6-promise';
 
 const t = assert;
 


### PR DESCRIPTION
Replace `bluebird` with `es6-promise`  in:

1. music-metadata
2. strtok3
3. then-readstream

Related issues:
* #107 
* captbaritone/webamp#606
