### PR TITLE
#13 Updated / add m4v episode tag mappings:

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Stream and file based music metadata parser for node.
 * [ASF](https://en.wikipedia.org/wiki/Advanced_Systems_Format)
 * EXIF 2.3
 * [ID3](https://wikipedia.org/wiki/ID3): ID3v1, ID3v1.1, ID3v2.2, [ID3v2.3](http://id3.org/id3v2.3.0) & [ID3v2.4](http://id3.org/id3v2.4.0-frames)
+* [iTunes](https://github.com/sergiomb2/libmp4v2/wiki/iTunesMetadata)
 * [RIFF](https://en.wikipedia.org/wiki/Resource_Interchange_File_Format)/INFO
 
 Support for [MusicBrainz](https://musicbrainz.org/) tags as written by [Picard](https://picard.musicbrainz.org/).

--- a/doc-gen/common.json
+++ b/doc-gen/common.json
@@ -23,11 +23,23 @@
   "album": {
     "description": "Album title"
   },
-  "show": {
+  "tvShow": {
     "description": "TV show title"
   },
-  "showsort": {
-    "description": "TV show sorting title"
+  "tvShowSort": {
+    "description": "TV show title, formatted for alphabetic ordering"
+  },
+  "tvSeason": {
+    "description": "TV season title"
+  },
+  "tvEpisode": {
+    "description": "TV episode title"
+  },
+  "tvEpisodeId": {
+    "description": "TV episode ID"
+  },
+  "tvNetwork": {
+    "description": "TV network"
   },
   "podcast": {
     "description": "_ToDo, see [issues #13](https://github.com/Borewit/music-metadata/issues/13)_"
@@ -84,16 +96,16 @@
     "description": "The canonical title of the [work](https://musicbrainz.org/doc/Work)"
   },
   "artistsort": {
-    "description": "Track artist sort name"
+    "description": "Track artist, formatted for alphabetic ordering"
   },
   "albumartistsort": {
-    "description": "Album artist sort name"
+    "description": "Album artist, formatted for alphabetic ordering"
   },
   "composersort": {
     "description": "Composer, formatted for alphabetic ordering"
   },
   "lyricist": {
-    "description": "Lyricist, formatted for alphabetic ordering"
+    "description": "Lyricist"
   },
   "writer": {
     "description": "Writer"
@@ -105,7 +117,7 @@
     "description": "Remixer(s)"
   },
   "arranger": {
-    "description": "Arranger"
+    "description": "Arranger(s)"
   },
   "engineer": {
     "description": "Engineer(s)"
@@ -150,7 +162,7 @@
     "description": "Keywords to reflect the mood of the audio, e.g. \"Romantic\" or \"Sad\""
   },
   "media": {
-    "description": "Release Format"
+    "description": "Release format"
   },
   "catalognumber": {
     "description": "[Release catalog number(s)](https://musicbrainz.org/doc/Release/Catalog_Number)"
@@ -247,6 +259,9 @@
   },
   "notes": {
     "description": "Similar to comments"
+  },
+  "description": {
+    "description": "Description"
   },
   "key": {
     "description": "The 'Initial key' frame contains the musical key in which the sound starts."

--- a/src/common/GenericTagTypes.ts
+++ b/src/common/GenericTagTypes.ts
@@ -1,4 +1,4 @@
-export type TagType = 'vorbis' | 'ID3v1' | 'ID3v2.2' | 'ID3v2.3' | 'ID3v2.4' | 'APEv2' | 'asf' | 'iTunes MP4' | 'exif';
+export type TagType = 'vorbis' | 'ID3v1' | 'ID3v2.2' | 'ID3v2.3' | 'ID3v2.4' | 'APEv2' | 'asf' | 'iTunes' | 'exif';
 
 export interface IGenericTag {
   id: GenericTagId,
@@ -50,8 +50,12 @@ export type GenericTagId =
   | 'mood'
   | 'media'
   | 'catalognumber'
-  | 'show'
-  | 'showsort'
+  | 'tvShow'
+  | 'tvShowSort'
+  | 'tvEpisode'
+  | 'tvEpisodeId'
+  | 'tvNetwork'
+  | 'tvSeason'
   | 'podcast'
   | 'podcasturl'
   | 'releasestatus'
@@ -95,7 +99,8 @@ export type GenericTagId =
   | 'discogs_release_id'
   | 'discogs_votes'
   | 'replaygain_track_gain'
-  | 'replaygain_track_peak';
+  | 'replaygain_track_peak'
+  | 'description';
 
 export interface INativeTagMap {
   [index: string]: GenericTagId;
@@ -161,8 +166,12 @@ export const commonTags: ITagInfoMap = {
   mood: {multiple: false},
   media: {multiple: false},
   catalognumber: {multiple: true, unique: true},
-  show: {multiple: false},
-  showsort: {multiple: false},
+  tvShow: {multiple: false},
+  tvShowSort: {multiple: false},
+  tvSeason: {multiple: false},
+  tvEpisode: {multiple: false},
+  tvEpisodeId: {multiple: false},
+  tvNetwork: {multiple: false},
   podcast: {multiple: false},
   podcasturl: {multiple: false},
   releasestatus: {multiple: false},
@@ -209,7 +218,9 @@ export const commonTags: ITagInfoMap = {
   discogs_rating: {multiple: false},
 
   replaygain_track_peak: {multiple: false},
-  replaygain_track_gain: {multiple: false}
+  replaygain_track_gain: {multiple: false},
+
+  description:  {multiple: true}
 };
 
 /**

--- a/src/common/MetadataCollector.ts
+++ b/src/common/MetadataCollector.ts
@@ -14,7 +14,7 @@ import {CommonTagMapper} from "./GenericTagMapper";
 
 const debug = _debug("music-metadata:collector");
 
-const TagPriority: TagType[] = ['APEv2', 'vorbis', 'ID3v2.4', 'ID3v2.3', 'ID3v2.2', 'exif', 'asf', 'iTunes MP4', 'ID3v1'];
+const TagPriority: TagType[] = ['APEv2', 'vorbis', 'ID3v2.4', 'ID3v2.3', 'ID3v2.2', 'exif', 'asf', 'iTunes', 'ID3v1'];
 
 /**
  * Combines all generic-tag-mappers for each tag type

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,10 +48,25 @@ export interface ICommonTagsResult {
    * Release year
    */
   year?: number;
+  /**
+   * Track title
+   */
   title?: string;
+  /**
+   * Track, maybe several artists written in a single string.
+   */
   artist?: string;
+  /**
+   * Track artists, aims to capture every artist in a different string.
+   */
   artists?: string[];
+  /**
+   * Track album artists
+   */
   albumartist?: string;
+  /**
+   * Album title
+   */
   album?: string;
   /**
    * Release data
@@ -65,25 +80,85 @@ export interface ICommonTagsResult {
    * Original release yeat
    */
   originalyear?: number;
+  /**
+   * List of comments
+   */
   comment?: string[];
+  /**
+   * Genre
+   */
   genre?: string[];
+  /**
+   * Embedded album art
+   */
   picture?: IPicture[];
+  /**
+   * Track composer
+   */
   composer?: string[];
+  /**
+   * Lyrics
+   */
   lyrics?: string[];
+  /**
+   * Album title, formatted for alphabetic ordering
+   */
   albumsort?: string;
+  /**
+   * Track title, formatted for alphabetic ordering
+   */
   titlesort?: string;
+  /**
+   * The canonical title of the work
+   */
   work?: string;
+  /**
+   * Track artist, formatted for alphabetic ordering
+   */
   artistsort?: string;
+  /**
+   * Album artist, formatted for alphabetic ordering
+   */
   albumartistsort?: string;
+  /**
+   * Composer(s), formatted for alphabetic ordering
+   */
   composersort?: string[];
+  /**
+   * Lyricist(s)
+   */
   lyricist?: string[];
+  /**
+   * Writer(s)
+   */
   writer?: string[];
+  /**
+   * Conductor(s)
+   */
   conductor?: string[];
+  /**
+   * Remixer(s)
+   */
   remixer?: string[];
+  /**
+   * Arranger(s)
+   */
   arranger?: string[];
+  /**
+   * Engineer(s)
+   */
   engineer?: string[];
+  /**
+   * Producer(s)
+   */
   producer?: string[];
+  /**
+   * Mix-DJ(s)
+   */
   djmixer?: string[];
+  /**
+   * Mixed by
+   */
   mixer?: string[];
   technician?: string[];
   label?: string[];
@@ -95,11 +170,38 @@ export interface ICommonTagsResult {
   compilation?: string;
   rating?: IRating[];
   bpm?: string;
+  /**
+   * Keywords to reflect the mood of the audio, e.g. 'Romantic' or 'Sad'
+   */
   mood?: string;
+  /**
+   * Release format, e.g. 'CD'
+   */
   media?: string;
+  /**
+   * Release catalog number(s)
+   */
   catalognumber?: string[];
-  show?: string;
-  showsort?: string;
+  /**
+   * TV show title
+   */
+  tvShow?: string;
+  /**
+   * TV show title, formatted for alphabetic ordering
+   */
+  tvShowSort?: string;
+  /**
+   * TV season title
+   */
+  tvSeason?: string;
+  /**
+   * TV episode ID
+   */
+  tvEpisodeID?: string,
+  /**
+   * TV network
+   */
+  tvNetwork?: string,
   podcast?: string;
   podcasturl?: string;
   releasestatus?: string;

--- a/src/mp4/MP4Parser.ts
+++ b/src/mp4/MP4Parser.ts
@@ -10,14 +10,15 @@ import util from "../common/Util";
 const debug = _debug("music-metadata:parser:MP4");
 import * as Token from "token-types";
 
-const tagFormat = 'iTunes MP4';
+const tagFormat = 'iTunes';
 
 /*
- * Parser for: MPEG-4 Audio / MPEG-4 Part 3 (m4a/mp4) extension.
- * Support for Apple iTunes MP4 tags as found in a M4A/MP4 file.
+ * Parser for: MPEG-4 Audio / Part 3 (.m4a)& MPEG 4 Video (m4v, mp4) extension.
+ * Support for Apple iTunes tags as found in a M4A/M4V files.
  * Ref:
  *   http://developer.apple.com/mac/library/documentation/QuickTime/QTFF/Metadata/Metadata.html
  *   http://atomicparsley.sourceforge.net/mpeg-4files.html
+ *   https://github.com/sergiomb2/libmp4v2/wiki/iTunesMetadata
  */
 export class MP4Parser extends BasicParser {
 
@@ -31,7 +32,7 @@ export class MP4Parser extends BasicParser {
 
   public parse(): Promise<void> {
 
-    this.metadata.setFormat('dataformat', 'MPEG-4 audio');
+    this.metadata.setFormat('dataformat', 'MPEG-4');
 
     const rootAtom = new Atom({name: 'mp4', length: this.tokenizer.fileSize}, false, null);
     return rootAtom.readAtoms(this.tokenizer, atom => {

--- a/src/mp4/MP4TagMapper.ts
+++ b/src/mp4/MP4TagMapper.ts
@@ -1,7 +1,9 @@
-import {ICommonTagsResult} from "../";
 import {INativeTagMap} from "../common/GenericTagTypes";
-import {CommonTagMapper, IGenericTagMapper} from "../common/GenericTagMapper";
+import {CommonTagMapper} from "../common/GenericTagMapper";
 
+/**
+ * Ref: https://github.com/sergiomb2/libmp4v2/wiki/iTunesMetadata
+ */
 const mp4TagMap: INativeTagMap = {
   '©nam': 'title',
   '©ART': 'artist',
@@ -40,8 +42,12 @@ const mp4TagMap: INativeTagMap = {
   '----:com.apple.iTunes:MOOD': 'mood',
   '----:com.apple.iTunes:MEDIA': 'media',
   '----:com.apple.iTunes:CATALOGNUMBER': 'catalognumber',
-  tvsh: 'show',
-  sosn: 'showsort',
+  tvsh: 'tvShow',
+  tvsn: 'tvSeason',
+  tves: 'tvEpisode',
+  sosn: 'tvShowSort',
+  tven: 'tvEpisodeId',
+  tvnn: 'tvNetwork',
   pcst: 'podcast',
   purl: 'podcasturl',
   '----:com.apple.iTunes:MusicBrainz Album Status': 'releasestatus',
@@ -76,14 +82,18 @@ const mp4TagMap: INativeTagMap = {
   '----:com.apple.iTunes:ALBUMARTISTSORT': 'albumartistsort',
   '----:com.apple.iTunes:ARTISTS': 'artists',
   '----:com.apple.iTunes:ORIGINALDATE': 'originaldate',
-  '----:com.apple.iTunes:ORIGINALYEAR': 'originalyear'
+  '----:com.apple.iTunes:ORIGINALYEAR': 'originalyear',
   // '----:com.apple.iTunes:PERFORMER': 'performer'
+  desc: 'description',
+  ldes: 'description'
 };
+
+export const tagType = 'iTunes';
 
 export class MP4TagMapper extends CommonTagMapper {
 
   public constructor() {
-    super(['iTunes MP4'],  mp4TagMap);
+    super([tagType],  mp4TagMap);
   }
 
 }

--- a/test/test-comment-mapping.ts
+++ b/test/test-comment-mapping.ts
@@ -116,7 +116,7 @@ describe("Mapping of common comment tag", () => {
 
   });
 
-  it("should map M4A / (Apple) iTunes MP4 header", () => {
+  it("should map M4A / (Apple) iTunes header", () => {
 
     const filePath = path.join(samples, "MusicBrainz - Beth Hart - Sinner's Prayer.m4a");
 

--- a/test/test-file-m4a.ts
+++ b/test/test-file-m4a.ts
@@ -5,16 +5,16 @@ import * as fs from 'fs-extra';
 
 const t = assert;
 
-describe("Read MPEG-4 audio files with iTunes metadata", () => {
+describe("Read MPEG-4 files with iTunes metadata", () => {
 
   const samples = path.join(__dirname, "samples");
 
-  describe("Parse MPEG-4 audio files (.m4a)", () => {
+  describe("Parse MPEG-4 files (.m4a)", () => {
 
     const filePath = path.join(__dirname, 'samples', 'id4.m4a');
 
     function checkFormat(format) {
-      assert.deepEqual(format.tagTypes, ['iTunes MP4'], 'format.tagTypes');
+      assert.deepEqual(format.tagTypes, ['iTunes'], 'format.tagTypes');
       t.strictEqual(format.duration, 2.2058956916099772, 'format.duration');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
     }
@@ -65,7 +65,7 @@ describe("Read MPEG-4 audio files with iTunes metadata", () => {
 
       return mm.parseFile(filePath, {native: true}).then(metadata => {
 
-        const native = metadata.native['iTunes MP4'];
+        const native = metadata.native.iTunes;
         t.ok(native, 'Native m4a tags should be present');
 
         checkFormat(metadata.format);
@@ -82,7 +82,7 @@ describe("Read MPEG-4 audio files with iTunes metadata", () => {
       return mm.parseStream(stream, 'audio/mp4', {native: true}).then(metadata => {
         checkFormat(metadata.format);
         checkCommon(metadata.common);
-        checkNativeTags(mm.orderTags(metadata.native['iTunes MP4']));
+        checkNativeTags(mm.orderTags(metadata.native.iTunes));
       }).then(() => {
         stream.close();
       });
@@ -97,9 +97,9 @@ describe("Read MPEG-4 audio files with iTunes metadata", () => {
 
     return mm.parseFile(filename, {native: true}).then(metadata => {
 
-      t.isDefined(metadata.native["iTunes MP4"], "Native m4a tags should be present");
+      t.isDefined(metadata.native.iTunes, 'Native m4a tags should be present');
       t.deepEqual(metadata.format.duration, 2.066575963718821, "metadata.format.duration");
-      const iTunes = mm.orderTags(metadata.native["iTunes MP4"]);
+      const iTunes = mm.orderTags(metadata.native.iTunes);
       t.deepEqual(iTunes.plID, [637567119], "iTunes.plID=637567119 (64-bit / 8-byte encoded uint");
       t.deepEqual(iTunes.cnID, [637567333], "iTunes.cnID (ITUNESCATALOGID) = 637567333");
     });
@@ -115,7 +115,7 @@ describe("Read MPEG-4 audio files with iTunes metadata", () => {
 
     return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
 
-      assert.isAtLeast(metadata.native['iTunes MP4'].length, 1);
+      assert.isAtLeast(metadata.native.iTunes.length, 1);
       t.deepEqual(metadata.common.album, "Live at Tom's Bullpen in Dover, DE (2016-04-30)");
       t.deepEqual(metadata.common.albumartist, "They Say We're Sinking");
       t.deepEqual(metadata.common.comment, ["youtube rip\r\nSource: https://www.youtube.com/playlist?list=PLZ4QPxwBgg9TfsFVAArOBfuve_0e7zQaV"]);
@@ -174,7 +174,7 @@ describe("Read MPEG-4 audio files with iTunes metadata", () => {
         assert.deepEqual(metadata.common.track, {no: 1, of: null});
         assert.deepEqual(metadata.common.comment, ['https://archive.org/details/glories_of_ireland_1801_librivox']);
 
-        const iTunes = mm.orderTags(metadata.native["iTunes MP4"]);
+        const iTunes = mm.orderTags(metadata.native.iTunes);
         assert.deepEqual(iTunes.stik, [2], 'iTunes.stik = 2 = Audiobook'); // Ref: http://www.zoyinc.com/?p=1004
       });
 
@@ -185,7 +185,7 @@ describe("Read MPEG-4 audio files with iTunes metadata", () => {
       const filePath = path.join(samples, 'issue-133.m4a');
 
       return mm.parseFile(filePath, {duration: true}).then(metadata => {
-        assert.deepEqual(metadata.format.dataformat, 'MPEG-4 audio');
+        assert.deepEqual(metadata.format.dataformat, 'MPEG-4');
       });
 
     });

--- a/test/test-mime.ts
+++ b/test/test-mime.ts
@@ -127,8 +127,8 @@ describe("MIME & extension mapping", () => {
       return testFileType('asf.wma', 'ASF/audio');
     });
 
-    it("should recognize MPEG-4 audio", () => {
-      return testFileType('MusicBrainz - Beth Hart - Sinner\'s Prayer.m4a', 'MPEG-4 audio');
+    it("should recognize MPEG-4", () => {
+      return testFileType('MusicBrainz - Beth Hart - Sinner\'s Prayer.m4a', 'MPEG-4');
     });
 
     it("should recognize FLAC", () => {

--- a/test/test-options.ts
+++ b/test/test-options.ts
@@ -146,7 +146,7 @@ describe("Parser options", () => {
 
     it("should include cover-art if option.skipCovers is not defined", () => {
       return mm.parseFile(file_m4a, {native: true}).then(result => {
-        const iTunes = mm.orderTags(result.native['iTunes MP4']);
+        const iTunes = mm.orderTags(result.native.iTunes);
         // Native
         t.isDefined(iTunes.covr, "iTunes.covr");
         // Common
@@ -156,7 +156,7 @@ describe("Parser options", () => {
 
     it("should not include cover-art if option.skipCovers=true", () => {
       return mm.parseFile(file_m4a, {native: true, skipCovers: true}).then(result => {
-        const iTunes = mm.orderTags(result.native['iTunes MP4']);
+        const iTunes = mm.orderTags(result.native.iTunes);
         // Native
         t.isUndefined(iTunes.covr, "m4a.covr");
         // Common
@@ -166,7 +166,7 @@ describe("Parser options", () => {
 
     it("should include cover-art if option.skipCovers=false", () => {
       return mm.parseFile(file_m4a, {native: true, skipCovers: false}).then(result => {
-        const iTunes = mm.orderTags(result.native['iTunes MP4']);
+        const iTunes = mm.orderTags(result.native.iTunes);
         // Native
         t.isDefined(iTunes.aART, "m4a.covr");
         // Common

--- a/test/test-picard-parsing.ts
+++ b/test/test-picard-parsing.ts
@@ -127,7 +127,7 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
     switch (inputTagType) {
 
       case 'APEv2':
-      case 'iTunes MP4':
+      case 'iTunes':
         break; // Skip rating tests for mapping type
 
       default:
@@ -546,12 +546,12 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
 
   });
 
-  it("should map M4A / (Apple) iTunes MP4 header", () => {
+  it("should map M4A / (Apple) iTunes header", () => {
 
     const filePath = path.join(samplePath,  "MusicBrainz - Beth Hart - Sinner's Prayer.m4a");
 
     function checkFormat(format: mm.IFormat) {
-      t.deepEqual(format.tagTypes, ['iTunes MP4'], 'format.tagTypes');
+      t.deepEqual(format.tagTypes, ['iTunes'], 'format.tagTypes');
       // t.strictEqual(format.dataformat, 'm4a', 'ToDo: M4A/ALAC');
       t.strictEqual(format.duration, 2.1229931972789116, 'format.duration');
       t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
@@ -588,11 +588,11 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
 
     // Run with default options
     return mm.parseFile(filePath, {native: true}).then(result => {
-      t.ok(result.native && result.native['iTunes MP4'], 'should include native M4A tags');
+      t.ok(result.native && result.native.iTunes, 'should include native M4A tags');
       checkFormat(result.format);
-      check_iTunes_Tags(mm.orderTags(result.native['iTunes MP4']));
+      check_iTunes_Tags(mm.orderTags(result.native.iTunes));
       checkCommonTags(result.common);
-      checkCommonMapping('iTunes MP4', result.common);
+      checkCommonMapping('iTunes', result.common);
     });
 
   });


### PR DESCRIPTION
Related to:
* issue #13
* requirement derived from: [easy-metadata](https://github.com/kyawswarthwin/easy-metadata/blob/2917567198b6f8090935fe865ea9851ef5efee3e/index.js#L28-L33)

Updated / add m4v episode tag mappings: 

| iTunes tag | generic (common tag) |
|-|-|
| tvsh | tvShow |
| tvsn | tvShow |
| tves | tvEpisode |
| sosn | tvShowSort |
| tven | tvEpisodeId |
| tvnn | tvNetwork |

Native iTunes tags now accessible via `native.iTunes` (was `native['iTunes MP4']`.