### PR TITLE
Allow file-size to be empty for an MPEG-4 audio track

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
  - "8"
  - "9"
  - "10"
+ - "11"
 install:
 - yarn install
 script:

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/file-type": "^5.2.1",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.11.7",
+    "axios": "^0.18.0",
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
     "del-cli": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
   "dependencies": {
     "debug": "^4.1.0",
     "file-type": "^10.0.0",
-    "media-typer": "^0.3.0",
-    "strtok3": "^2.1.0",
+    "media-typer": "0.3.0",
+    "strtok3": "^2.1.1",
     "then-read-stream": "^1.3.1",
-    "token-types": "^1.0.0"
+    "token-types": "^1.0.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.6",

--- a/src/mp4/Atom.ts
+++ b/src/mp4/Atom.ts
@@ -24,7 +24,7 @@ export class Atom {
 
     return this.readAtom(tokenizer, dataHandler).then(atomBean => {
       this.children.push(atomBean);
-      if (!size) {
+      if (size === undefined) {
         return this.readAtoms(tokenizer, dataHandler, size).catch(err => {
           if (err.message === endOfFile) {
             debug(`Reached end-of-file`);

--- a/src/mp4/Atom.ts
+++ b/src/mp4/Atom.ts
@@ -1,14 +1,12 @@
-import {ITokenizer} from "strtok3/lib/type";
-
+import {ITokenizer, endOfFile} from "strtok3/lib/type";
 import * as initDebug from "debug";
-
-const debug = initDebug("music-metadata:parser:MP4:Atom");
+import * as Token from "token-types";
 
 import * as AtomToken from "./AtomToken";
 
-import * as Token from "token-types";
-
 export type AtomDataHandler = (atom: Atom) => Promise<void>;
+
+const debug = initDebug("music-metadata:parser:MP4:Atom");
 
 export class Atom {
 
@@ -26,6 +24,15 @@ export class Atom {
 
     return this.readAtom(tokenizer, dataHandler).then(atomBean => {
       this.children.push(atomBean);
+      if (!size) {
+        return this.readAtoms(tokenizer, dataHandler, size).catch(err => {
+          if (err.message === endOfFile) {
+            debug(`Reached end-of-file`);
+          } else {
+            throw err;
+          }
+        });
+      }
       size -= atomBean.header.length;
       if (size > 0) {
         return this.readAtoms(tokenizer, dataHandler, size);

--- a/src/mp4/MP4Parser.ts
+++ b/src/mp4/MP4Parser.ts
@@ -47,7 +47,7 @@ export class MP4Parser extends BasicParser {
 
         case "ftyp":
           return this.parseAtom_ftyp(atom.dataLen).then(types => {
-            debug('ftyp: ' + types.join('/'));
+            debug(`ftyp: ${types.join('/')}`);
           });
 
         case 'mdhd': // Media header atom

--- a/src/mp4/MP4Parser.ts
+++ b/src/mp4/MP4Parser.ts
@@ -59,7 +59,7 @@ export class MP4Parser extends BasicParser {
 
       return this.tokenizer.readToken<Buffer>(new Token.IgnoreType(atom.dataLen))
         .then(() => {
-          debug("Ignore atom data: path=%s, payload-len=%s", atom.atomPath, atom.dataLen);
+          debug(`Ignore atom data: path=${atom.atomPath}, payload-len=${atom.dataLen}`);
         });
 
     }, this.tokenizer.fileSize);

--- a/test/test-http.ts
+++ b/test/test-http.ts
@@ -1,0 +1,97 @@
+import { assert } from 'chai';
+
+import * as Stream from 'stream';
+import * as http from 'http';
+import * as https from 'https';
+
+import * as mm from '../lib';
+import { IOptions } from '../src/type';
+
+interface IHttpResponse {
+  headers: { [id: string]: string; }
+  stream: Stream.Readable;
+}
+
+interface IHttpClient {
+  get: (url: string) => Promise<IHttpResponse>;
+}
+
+interface IHttpClientTest {
+  readonly name: string;
+  client: IHttpClient;
+}
+
+class NodeHttpClient {
+
+  public get(url: string): Promise<IHttpResponse> {
+    return new Promise<IHttpResponse>((resolve, reject) => {
+      const request = ((url.startsWith('https') ? https : http) as typeof http).get(url);
+      request.on('response', resp => {
+        resolve({
+          headers: resp.headers as any,
+          stream: resp
+        });
+      });
+      request.on('abort', () => {
+        reject(new Error('abort'));
+      });
+      request.on('error', err => {
+        reject(err);
+      });
+    });
+  }
+}
+
+const clients: IHttpClientTest[] = [
+
+  {
+    name: 'http',
+    client: new NodeHttpClient()
+  }
+
+];
+
+describe('HTTP streaming', function() {
+
+  // Increase time-out to 15 seconds because we retrieve files over HTTP(s)
+  this.timeout(15 * 1000);
+  this.retries(3); // Workaround for HTTP time-outs on Travis-CI
+
+  describe('Stream HTTP using different clients', () => {
+
+    clients.forEach(test => {
+
+      describe(`HTTP client: ${test.name}`, () => {
+
+        [true, false].forEach(hasContentLength => {
+
+          it(`Should be able to parse M4A ${hasContentLength ? 'with' : 'without'} content-length specified`, () => {
+
+            const url = 'https://tunalib.s3.eu-central-1.amazonaws.com/plan.m4a';
+
+            return test.client.get(url).then(response => {
+
+              const options: IOptions = {};
+              if (hasContentLength) {
+                options.fileSize = parseInt(response.headers['content-length'], 10); // Always pass this in production
+              }
+
+              return mm.parseStream(response.stream, response.headers['content-type'], options)
+                .then(tags => {
+                  if (response.stream.destroy) {
+                    response.stream.destroy(); // Node >= v8 only
+                  }
+                  assert.strictEqual(tags.common.title, 'We Made a Plan');
+                  assert.strictEqual(tags.common.artist, 'Adan Cruz');
+                  assert.strictEqual(tags.common.album, 'Quiérelo');
+                });
+            });
+          });
+
+        });
+
+      });
+    });
+  });
+
+});

--- a/test/test-http.ts
+++ b/test/test-http.ts
@@ -51,7 +51,8 @@ const clients: IHttpClientTest[] = [
 
 ];
 
-describe('HTTP streaming', function() {
+// Skipped: https://github.com/Borewit/music-metadata/issues/160
+describe.skip('HTTP streaming', function() {
 
   // Increase time-out to 15 seconds because we retrieve files over HTTP(s)
   this.timeout(15 * 1000);

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,6 +227,13 @@ aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -497,7 +504,7 @@ debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@3.1.0, debug@^3.1.0:
+debug@3.1.0, debug@=3.1.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -703,6 +710,12 @@ find-up@^3.0.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
   dependencies:
     locate-path "^3.0.0"
+
+follow-redirects@^1.3.0:
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.9.tgz#c9ed9d748b814a39535716e531b9196a845d89c6"
+  dependencies:
+    debug "=3.1.0"
 
 foreach@^2.0.5:
   version "2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,12 +510,6 @@ debug@3.1.0, debug@=3.1.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.0.1.tgz#f9bb36d439b8d1f0dd52d8fb6b46e4ebb8c1cd5b"
-  dependencies:
-    ms "^2.1.1"
-
 debug@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
@@ -1259,9 +1253,9 @@ md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
 
-media-typer@^0.3.0:
+media-typer@0.3.0:
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  resolved "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
 mem@^1.1.0:
   version "1.1.0"
@@ -1954,13 +1948,13 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-strtok3@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-2.1.0.tgz#f1e3aab64c15dadd23b09fdf9788afd11031b85a"
+strtok3@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-2.1.1.tgz#33772fc5e2b5872c4af7271187479de7bfd60c11"
   dependencies:
-    debug "^4.0.1"
-    then-read-stream "^1.3.0"
-    token-types "^1.0.0"
+    debug "^4.1.0"
+    then-read-stream "^1.3.1"
+    token-types "^1.0.1"
 
 supports-color@5.4.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
@@ -1987,10 +1981,6 @@ test-exclude@^5.0.0:
     read-pkg-up "^4.0.0"
     require-main-filename "^1.0.1"
 
-then-read-stream@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/then-read-stream/-/then-read-stream-1.3.0.tgz#fb99314d1c5845fea29e5d271f261a1259039c09"
-
 then-read-stream@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/then-read-stream/-/then-read-stream-1.3.1.tgz#81f91fa31d8044bd9a6d49b84af4fb6b34b5cfc7"
@@ -2007,9 +1997,9 @@ to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
-token-types@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/token-types/-/token-types-1.0.0.tgz#91f8180eb5464abb28af361ced3ac855a1e18fb2"
+token-types@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-1.0.1.tgz#c91671bd80f7e2ded10dee4b8ff17247c40378c7"
 
 tough-cookie@~2.3.3:
   version "2.3.4"


### PR DESCRIPTION
Fix for issue #156, where MPEG-4 audio return with empty result if read from a stream and no file-size is specified.