### PR TITLE
 Make lazy loading of parser modules more browser friendly

### DIFF
--- a/src/ParserFactory.ts
+++ b/src/ParserFactory.ts
@@ -133,7 +133,7 @@ export class ParserFactory {
       }
       return parser;
     }
-    const module = require('./' + moduleName + '/index');
+    const module = await import('./' + moduleName + '/index');
     return new module.default();
   }
 


### PR DESCRIPTION
Use `await import` for loading parser modules.

To address: Borewit/music-metadata-browser#14