### PR TITLE
Normalize replay-gain values in common

### DIFF
--- a/doc-gen/common.json
+++ b/doc-gen/common.json
@@ -276,10 +276,10 @@
     "description": "Discogs release identifier"
   },
   "replaygain_track_peak": {
-    "description": "Replaygain track peak"
+    "description": "Replaygain track peak: {ratio: number, dB: number}"
   },
   "replaygain_track_gain": {
-    "description": "Replay track gain"
+    "description": "Replay track gain: {ratio: number, dB: number}"
   },
   "technician": {
     "description": "Technician who digitized subject"

--- a/src/apev2/APEv2Parser.ts
+++ b/src/apev2/APEv2Parser.ts
@@ -80,7 +80,7 @@ export class APEv2Parser extends BasicParser {
 
   private static parseTagFooter(metadata: INativeMetadataCollector, buffer: Buffer, includeCovers: boolean) {
     const footer = TagFooter.get(buffer, buffer.length - TagFooter.len);
-    assert.equal(footer.ID, preamble, 'APEv2 Footer preamble');
+    assert.strictEqual(footer.ID, preamble, 'APEv2 Footer preamble');
     this.parseTags(metadata, footer, buffer, buffer.length - footer.size, includeCovers);
   }
 
@@ -154,7 +154,7 @@ export class APEv2Parser extends BasicParser {
 
     const descriptor = await this.tokenizer.readToken(DescriptorParser);
 
-    assert.equal(descriptor.ID, 'MAC ', 'descriptor.ID');
+    assert.strictEqual(descriptor.ID, 'MAC ', 'descriptor.ID');
     this.ape.descriptor = descriptor;
     const lenExp = descriptor.descriptorBytes - DescriptorParser.len;
     const header = await(lenExp > 0 ? this.parseDescriptorExpansion(lenExp) : this.parseHeader());

--- a/src/apev2/APEv2TagMapper.ts
+++ b/src/apev2/APEv2TagMapper.ts
@@ -1,5 +1,6 @@
 import {INativeTagMap} from "../common/GenericTagTypes";
 import {CommonTagMapper} from "../common/GenericTagMapper";
+import {ITag} from "../type";
 
 /**
  * ID3v2.2 tag mappings

--- a/src/common/MetadataCollector.ts
+++ b/src/common/MetadataCollector.ts
@@ -10,6 +10,7 @@ import * as _debug from "debug";
 import {GenericTagId, IGenericTag, TagType, isSingleton, isUnique} from "./GenericTagTypes";
 import {CombinedTagMapper} from "./CombinedTagMapper";
 import {CommonTagMapper} from "./GenericTagMapper";
+import {toRatio} from "./Util";
 
 const debug = _debug("music-metadata:collector");
 
@@ -196,8 +197,9 @@ export class MetadataCollector implements INativeMetadataCollector {
         tag.value = typeof tag.value === 'string' ? parseInt(tag.value, 10) : tag.value;
         break;
 
+      case 'replaygain_track_gain':
       case 'replaygain_track_peak':
-        tag.value = typeof tag.value === 'string' ? parseFloat(tag.value) : tag.value;
+        tag.value = toRatio(tag.value);
         break;
 
       case 'gapless': // iTunes gap-less flag

--- a/src/common/Util.ts
+++ b/src/common/Util.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import {Windows1292Decoder} from './Windows1292Decoder';
+import {IRatio} from "../type";
 
 export type StringEncoding = 'iso-8859-1' | 'utf16' | 'utf8' | 'utf8' | 'utf16le';
 
@@ -140,4 +141,43 @@ export default class Util {
     return arr.join(' ');
   }
 
+}
+
+/**
+ * Convert power ratio to DB
+ * ratio: [0..1]
+ */
+export function ratioToDb(ratio: number): number {
+  return 10 * Math.log10(ratio);
+}
+
+/**
+ * Convert dB to ratio
+ * db Decibels
+ */
+export function dbToRatio(dB: number): number {
+  return Math.pow(10, dB / 10);
+}
+
+/**
+ * Convert replay gain to ratio and Decibel
+ * @param value string holding a ratio like '0.034' or '-7.54 dB'
+ */
+export function toRatio(value: string): IRatio {
+  const ps = value.split(' ').map(p => p.trim().toLowerCase());
+  // @ts-ignore
+  if (ps.length >= 1) {
+    const v = parseFloat(ps[0]);
+    if (ps.length === 2 && ps[1] === 'db') {
+      return {
+        dB: v,
+        ratio: dbToRatio(v)
+      };
+    } else {
+      return {
+        dB: ratioToDb(v),
+        ratio: v
+      };
+    }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import * as Core from './core';
 import { MetadataCollector } from './common/MetadataCollector';
 import { ParserFactory } from './ParserFactory';
 import {IAudioMetadata, IOptions, ITag, INativeTagDict, ICommonTagsResult} from './type';
-export {IAudioMetadata, IOptions, ITag, INativeTagDict, ICommonTagsResult, IFormat, IPicture} from './type';
+export {IAudioMetadata, IOptions, ITag, INativeTagDict, ICommonTagsResult, IFormat, IPicture, IRatio} from './type';
 
 /**
  * Parse audio from Node Stream.Readable

--- a/src/type.ts
+++ b/src/type.ts
@@ -247,14 +247,35 @@ export interface ICommonTagsResult {
   discogs_rating?: number;
 
   /**
-   * Track gain in dB; eg: "-7.03 dB"
+   * Track gain ratio [0..1]
    */
-  replaygain_track_gain?: string;
+  replaygain_track_gain_ratio?: number;
   /**
-   * Track peak [0..1]
+   * Track peak ratio [0..1]
    */
-  replaygain_track_peak?: number;
+  replaygain_track_peak_ratio?: number;
 
+  /**
+   * Track gain ratio
+   */
+  replaygain_track_gain?: IRatio;
+  /**
+   * Track peak ratio
+   */
+  replaygain_track_peak?: IRatio;
+
+}
+
+export interface IRatio {
+  /**
+   * [0..1]
+   */
+  ratio: number;
+
+  /**
+   * Decibel
+   */
+  dB: number;
 }
 
 export type FormatId =

--- a/test/test-replaygain.ts
+++ b/test/test-replaygain.ts
@@ -1,19 +1,38 @@
-import {assert} from "chai";
-import * as mm from "../src";
+import {assert} from 'chai';
+import * as mm from '../src';
 
-import * as path from "path";
+import * as path from 'path';
 
-const t = assert;
+import {ratioToDb, dbToRatio, toRatio} from '../src/common/Util';
 
 describe("Decode replaygain tags", () => {
 
-  const filePath = path.join(__dirname, "samples", "04 Long Drive.flac");
+  const filePath = path.join(__dirname, 'samples', '04 Long Drive.flac');
 
-  it("should decode replaygain tags from FLAC/Vorbis", () => {
+  it('Convert ratio to dB', () => {
+
+    assert.approximately(ratioToDb(0.99914551), -0.00371259, 0.000000005);
+  });
+
+  it('Convert dB to ratio', () => {
+
+    assert.approximately(dbToRatio(-7.03), 0.19815270, 0.000000005);
+  });
+
+  it('Convert dB string value to IRatio', () => {
+
+    assert.deepEqual(toRatio('-7.03 dB'), {
+      dB: -7.03,
+      ratio: 0.1981527025805098
+    });
+    assert.deepEqual(toRatio('xxx'), {dB: NaN, ratio: NaN});
+  });
+
+  it('should decode replaygain tags from FLAC/Vorbis', () => {
 
     return mm.parseFile(filePath, {native: true}).then(metadata => {
-      t.strictEqual(metadata.common.replaygain_track_gain, "-7.03 dB", "common.replaygain_track_gain");
-      t.strictEqual(metadata.common.replaygain_track_peak, 0.99914551, "common.replaygain_track_peak");
+      assert.deepEqual(metadata.common.replaygain_track_gain, {dB: -7.03, ratio: 0.1981527025805098}, 'replaygain_track_gain.ratio');
+      assert.deepEqual(metadata.common.replaygain_track_peak, {dB: -0.0037125893296365503, ratio: 0.99914551}, 'replaygain_track_peak.ratio = -0.00371259 dB');
     });
   });
 


### PR DESCRIPTION
Return the replay values:
1. `replaygain_track_gain`
2. `replaygain_track_peak`
as an `IRatio` value e.g.: 
```javascript
{
  dB: -7.03, // ratio in decibel
  ratio: 0.1981527025805098 // ratio [0..1]
}
```
Related to issue: #191