### PR TITLE
Update API: renamed format properties: dataformat to container & enco…

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,14 +232,14 @@ If the returned promise resolves, the metadata (TypeScript `IAudioMetadata` inte
 #### Format
   
 Audio format information. Defined in the TypeScript `IFormat` interface:
-*   `dataformat?: string` Audio encoding format. e.g.: 'flac'
+*   `container?: string` Audio encoding format. e.g.: 'flac'
+*   `codec?` Name of the codec (algorithm used for the audio compression)
+*   `codecProfile?: string` Codec profile / settings
 *   `tagTypes?: TagType[]`  List of tagging formats found in parsed audio file
 *   `duration?: number` Duration in seconds
 *   `bitrate?: number` Number bits per second of encoded audio file
 *   `sampleRate?: number` Sampling rate in Samples per second (S/s)
 *   `bitsPerSample?: number` Audio bit depth
-*   `encoder?` Encoder name
-*   `codecProfile?: string` Codec profile
 *   `lossless?: boolean` True if lossless,  false for lossy encoding
 *   `numberOfChannels?: number` Number of audio channels
 *   `numberOfSamples?: number` Number of samples frames, one sample contains all channels. The duration is: numberOfSamples / sampleRate
@@ -270,7 +270,7 @@ mm.parseStream(someReadStream, 'audio/mpeg', { duration: true, fileSize: 26838 }
     1.  Using recursion
 
         ```javascript
-        const mm = require('music-metadata')z
+        const mm = require('music-metadata')
         
         function parseFiles(audioFiles) {
           

--- a/src/aiff/AiffParser.ts
+++ b/src/aiff/AiffParser.ts
@@ -36,12 +36,12 @@ export class AIFFParser extends BasicParser {
     switch (type) {
 
       case 'AIFF':
-        this.metadata.setFormat('dataformat', type);
+        this.metadata.setFormat('container', type);
         this.isCompressed = false;
         break;
 
       case 'AIFC':
-        this.metadata.setFormat('dataformat', 'AIFF-C');
+        this.metadata.setFormat('container', 'AIFF-C');
         this.isCompressed = true;
         break;
 
@@ -76,7 +76,7 @@ export class AIFFParser extends BasicParser {
         this.metadata.setFormat('numberOfChannels', common.numChannels);
         this.metadata.setFormat('numberOfSamples', common.numSampleFrames);
         this.metadata.setFormat('duration', common.numSampleFrames / common.sampleRate);
-        this.metadata.setFormat('encoder', common.compressionName);
+        this.metadata.setFormat('codec', common.compressionName);
         return header.chunkSize;
 
       case 'ID3 ': // ID3-meta-data

--- a/src/apev2/APEv2Parser.ts
+++ b/src/apev2/APEv2Parser.ts
@@ -172,7 +172,7 @@ export class APEv2Parser extends BasicParser {
     const header = await this.tokenizer.readToken(Header);
     // ToDo before
     this.metadata.setFormat('lossless', true);
-    this.metadata.setFormat('dataformat', 'Monkey\'s Audio');
+    this.metadata.setFormat('container', 'Monkey\'s Audio');
 
     this.metadata.setFormat('bitsPerSample', header.bitsPerSample);
     this.metadata.setFormat('sampleRate', header.sampleRate);

--- a/src/asf/AsfParser.ts
+++ b/src/asf/AsfParser.ts
@@ -53,7 +53,7 @@ export class AsfParser extends BasicParser {
 
         case AsfObject.StreamPropertiesObject.guid.str: // 3.3
           const spo = await this.tokenizer.readToken<AsfObject.IStreamPropertiesObject>(new AsfObject.StreamPropertiesObject(header));
-          this.metadata.setFormat('dataformat', 'ASF/' + spo.streamType);
+          this.metadata.setFormat('container', 'ASF/' + spo.streamType);
           break;
 
         case AsfObject.HeaderExtensionObject.guid.str: // 3.4

--- a/src/dsdiff/DsdiffParser.ts
+++ b/src/dsdiff/DsdiffParser.ts
@@ -28,7 +28,7 @@ export class DsdiffParser extends BasicParser {
     switch (type) {
 
       case 'DSD':
-        this.metadata.setFormat('dataformat', `DSDIFF/${type}`);
+        this.metadata.setFormat('container', `DSDIFF/${type}`);
         this.metadata.setFormat('lossless', true);
         return this.readFmt8Chunks(header.chunkSize - FourCcToken.len);
 
@@ -116,7 +116,7 @@ export class DsdiffParser extends BasicParser {
             this.metadata.setFormat('lossless', true);
             this.metadata.setFormat('bitsPerSample', 1);
           }
-          this.metadata.setFormat('encoder', `${compressionIdCode} (${compressionName})`);
+          this.metadata.setFormat('codec', `${compressionIdCode} (${compressionName})`);
           break;
 
         case 'ABSS': // 3.2.4 Absolute Start Time Chunk

--- a/src/dsf/DsfParser.ts
+++ b/src/dsf/DsfParser.ts
@@ -20,7 +20,7 @@ export class DsfParser extends AbstractID3Parser {
     const p0 = this.tokenizer.position; // mark start position, normally 0
     const chunkHeader = await this.tokenizer.readToken<IChunkHeader>(ChunkHeader);
     assert.strictEqual(chunkHeader.id, 'DSD ', 'Invalid chunk signature');
-    this.metadata.setFormat('dataformat', 'DSF');
+    this.metadata.setFormat('container', 'DSF');
     this.metadata.setFormat('lossless', true);
     const dsdChunk = await this.tokenizer.readToken<IDsdChunk>(DsdChunk);
     if (dsdChunk.metadataPointer === 0) {

--- a/src/flac/FlacParser.ts
+++ b/src/flac/FlacParser.ts
@@ -92,7 +92,7 @@ export class FlacParser extends AbstractID3Parser {
       throw new Error('Unexpected block-stream-info length');
 
     const streamInfo = await this.tokenizer.readToken<IBlockStreamInfo>(Metadata.BlockStreamInfo);
-    this.metadata.setFormat('dataformat', 'flac');
+    this.metadata.setFormat('container', 'flac');
     this.metadata.setFormat('lossless', true);
     this.metadata.setFormat('numberOfChannels', streamInfo.channels);
     this.metadata.setFormat('bitsPerSample', streamInfo.bitsPerSample);

--- a/src/mp4/MP4Parser.ts
+++ b/src/mp4/MP4Parser.ts
@@ -96,7 +96,7 @@ export class MP4Parser extends BasicParser {
         case "ftyp":
           const types = await this.parseAtom_ftyp(atom.dataLen);
           debug(`ftyp: ${types.join('/')}`);
-          this.metadata.setFormat('dataformat', types.filter(distinct).join('/'));
+          this.metadata.setFormat('container', types.filter(distinct).join('/'));
           return;
 
         case 'mdhd': // Media header atom
@@ -117,7 +117,7 @@ export class MP4Parser extends BasicParser {
 
     }, this.tokenizer.fileSize);
 
-    this.metadata.setFormat('encoder', this.formatList.filter(distinct).join('+'));
+    this.metadata.setFormat('codec', this.formatList.filter(distinct).join('+'));
   }
 
   private addTag(id: string, value: any) {

--- a/src/mpeg/MpegParser.ts
+++ b/src/mpeg/MpegParser.ts
@@ -420,8 +420,8 @@ export class MpegParser extends AbstractID3Parser {
     }
     await this.tokenizer.ignore(3);
 
-    this.metadata.setFormat('dataformat', header.container);
-    this.metadata.setFormat('encoder', header.codec);
+    this.metadata.setFormat('container', header.container);
+    this.metadata.setFormat('codec', header.codec);
     this.metadata.setFormat('lossless', false);
     this.metadata.setFormat('sampleRate', header.samplingRate);
 
@@ -579,7 +579,7 @@ export class MpegParser extends AbstractID3Parser {
     const infoTag = await this.tokenizer.readToken<IXingInfoTag>(XingInfoTag);
     this.offset += XingInfoTag.len;  // 12
 
-    this.metadata.setFormat('tool', Common.stripNulls(infoTag.encoder));
+    this.metadata.setFormat('tool', Common.stripNulls(infoTag.codec));
 
     if ((infoTag.headerFlags[3] & 0x01) === 1) {
       const duration = this.audioFrameHeader.calcDuration(infoTag.numFrames);

--- a/src/mpeg/XingTag.ts
+++ b/src/mpeg/XingTag.ts
@@ -38,7 +38,7 @@ export interface IXingInfoTag {
    */
 
   //  Initial LAME info, e.g.: LAME3.99r
-  encoder: string,
+  codec: string,
   /**
    * Info tag revision
    */
@@ -80,7 +80,7 @@ export const XingInfoTag: Token.IGetToken<IXingInfoTag> = {
       // === ZONE B - Initial LAME info  ===
 
       //  Initial LAME info, e.g.: LAME3.99r
-      encoder: new Token.StringType(9, 'ascii').get(buf, off + 116), // bytes $9A-$A => 154-164 (offset doc - 38)
+      codec: new Token.StringType(9, 'ascii').get(buf, off + 116), // bytes $9A-$A => 154-164 (offset doc - 38)
       // 	 Info tag revision
       infoTagRevision: Token.UINT8.get(buf, off + 125) >> 4,
       // VBR method

--- a/src/musepack/sv7/MpcSv7Parser.ts
+++ b/src/musepack/sv7/MpcSv7Parser.ts
@@ -22,7 +22,7 @@ export class MpcSv7Parser extends BasicParser {
 
     assert.equal(header.signature, 'MP+', 'Magic number');
     debug(`stream-version=${header.streamMajorVersion}.${header.streamMinorVersion}`);
-    this.metadata.setFormat('dataformat', 'Musepack, SV7');
+    this.metadata.setFormat('container', 'Musepack, SV7');
     this.metadata.setFormat('sampleRate', header.sampleFrequency);
     const numberOfSamples = 1152 * (header.frameCount - 1) + header.lastFrameLength;
     this.metadata.setFormat('numberOfSamples', numberOfSamples);
@@ -31,7 +31,7 @@ export class MpcSv7Parser extends BasicParser {
     this.bitreader = new BitReader(this.tokenizer);
     this.metadata.setFormat('numberOfChannels', header.midSideStereo || header.intensityStereo ? 2 : 1);
     const version = await this.bitreader.read(8);
-    this.metadata.setFormat('encoder', (version / 100).toFixed(2));
+    this.metadata.setFormat('codec', (version / 100).toFixed(2));
     await this.skipAudioData(header.frameCount);
     debug(`End of audio stream, switching to APEv2, offset=${this.tokenizer.position}`);
     return APEv2Parser.parseTagHeader(this.metadata, this.tokenizer, this.options);

--- a/src/musepack/sv8/MpcSv8Parser.ts
+++ b/src/musepack/sv8/MpcSv8Parser.ts
@@ -18,7 +18,7 @@ export class MpcSv8Parser extends BasicParser {
 
     const signature = await this.tokenizer.readToken(FourCcToken);
     assert.equal(signature, 'MPCK', 'Magic number');
-    this.metadata.setFormat('dataformat', 'Musepack, SV8');
+    this.metadata.setFormat('container', 'Musepack, SV8');
     return this.parsePacket();
   }
 

--- a/src/ogg/OggParser.ts
+++ b/src/ogg/OggParser.ts
@@ -107,7 +107,7 @@ export class OggParser extends BasicParser {
             default:
               throw new Error('gg audio-codec not recognized (id=' + id + ')');
           }
-          this.metadata.setFormat('dataformat', 'Ogg/' + this.pageConsumer.codecName);
+          this.metadata.setFormat('container', 'Ogg/' + this.pageConsumer.codecName);
         }
         this.pageConsumer.parsePage(header, pageData);
       } while (!header.headerType.lastPage);

--- a/src/ogg/speex/SpeexParser.ts
+++ b/src/ogg/speex/SpeexParser.ts
@@ -36,7 +36,7 @@ export class SpeexParser extends VorbisParser {
     speexHeader = speexHeader;
     this.metadata.setFormat('numberOfChannels', speexHeader.nb_channels);
     this.metadata.setFormat('sampleRate', speexHeader.rate);
-    this.metadata.setFormat('encoder', speexHeader.version);
+    this.metadata.setFormat('codec', speexHeader.version);
     if (speexHeader.bitrate !== -1) {
       this.metadata.setFormat('bitrate', speexHeader.bitrate);
     }

--- a/src/riff/WaveParser.ts
+++ b/src/riff/WaveParser.ts
@@ -47,7 +47,7 @@ export class WaveParser extends BasicParser {
 
   public async parseRiffChunk(): Promise<void> {
     const type = await this.tokenizer.readToken<string>(FourCcToken);
-    this.metadata.setFormat('dataformat', type);
+    this.metadata.setFormat('container', type);
     switch (type) {
       case 'WAVE':
         return this.readWaveChunk();
@@ -82,7 +82,7 @@ export class WaveParser extends BasicParser {
             debug('WAVE/non-PCM format=' + fmt.wFormatTag);
             subFormat = 'non-PCM (' + fmt.wFormatTag + ')';
           }
-          this.metadata.setFormat('dataformat', 'WAVE/' + subFormat);
+          this.metadata.setFormat('container', 'WAVE/' + subFormat);
           this.metadata.setFormat('bitsPerSample', fmt.wBitsPerSample);
           this.metadata.setFormat('sampleRate', fmt.nSamplesPerSec);
           this.metadata.setFormat('numberOfChannels', fmt.nChannels);

--- a/src/type.ts
+++ b/src/type.ts
@@ -258,12 +258,12 @@ export interface ICommonTagsResult {
 }
 
 export type FormatId =
-  'dataformat'
+  'container'
   | 'duration'
   | 'bitrate'
   | 'sampleRate'
   | 'bitsPerSample'
-  | 'encoder'
+  | 'codec'
   | 'tool'
   | 'codecProfile'
   | 'lossless'
@@ -276,7 +276,7 @@ export interface IFormat {
   /**
    * E.g.: 'flac'
    */
-  readonly dataformat?: string, // ToDo: make mandatory
+  readonly container?: string, // ToDo: make mandatory
 
   /**
    * List of tags found in parsed audio file
@@ -311,7 +311,7 @@ export interface IFormat {
   /**
    * Encoder name / compressionType, e.g.: 'PCM', 'ITU-T G.711 mu-law'
    */
-  readonly encoder?: string,
+  readonly codec?: string,
 
   /**
    * Codec profile

--- a/src/wavpack/WavPackParser.ts
+++ b/src/wavpack/WavPackParser.ts
@@ -39,8 +39,8 @@ export class WavPackParser extends BasicParser {
 
       debug(`WavPack header blockIndex=${header.blockIndex}, len=${WavPack.BlockHeaderToken.len}`);
 
-      if (header.blockIndex === 0 && !this.metadata.format.dataformat) {
-        this.metadata.setFormat('dataformat', 'WavPack');
+      if (header.blockIndex === 0 && !this.metadata.format.container) {
+        this.metadata.setFormat('container', 'WavPack');
         this.metadata.setFormat('lossless', !header.flags.isHybrid);
         // tagTypes: this.type,
         this.metadata.setFormat('bitsPerSample', header.flags.bitsPerSample);

--- a/test/test-async.ts
+++ b/test/test-async.ts
@@ -26,7 +26,7 @@ describe("Asynchronous observer updates", () => {
       .then(metadata => {
         assert.deepEqual(eventTags, [
           {
-            id: 'dataformat',
+            id: 'container',
             type: 'format',
             value: 'flac'
           },

--- a/test/test-dsdiff.ts
+++ b/test/test-dsdiff.ts
@@ -13,7 +13,7 @@ describe('Parse Philips DSDIFF', () => {
     const {format, common} = await mm.parseFile(filePath, {duration: false});
 
     // format chunk information
-    assert.strictEqual(format.dataformat, 'DSDIFF/DSD');
+    assert.strictEqual(format.container, 'DSDIFF/DSD');
     assert.deepEqual(format.lossless, true);
     assert.deepEqual(format.tagTypes, ['ID3v2.3']);
     assert.deepEqual(format.numberOfChannels, 2, 'format.numberOfChannels');

--- a/test/test-file-aac.ts
+++ b/test/test-file-aac.ts
@@ -15,8 +15,8 @@ describe("Parse ADTS/AAC", () => {
   const samplePath = path.join(__dirname, 'samples', 'aac');
 
   function checkFormat(format: IFormat, dataFormat: string, codec: string, codecProfile: string, sampleRate: number, channels: number, bitrate: number, samples?: number) {
-    t.strictEqual(format.dataformat, dataFormat, 'format.dataformat');
-    t.strictEqual(format.encoder, codec, 'format.encoder');
+    t.strictEqual(format.container, dataFormat, 'format.container');
+    t.strictEqual(format.codec, codec, 'format.codec');
     t.strictEqual(format.codecProfile, codecProfile, 'format.codecProfile');
     t.strictEqual(format.lossless, false, 'format.lossless');
     t.strictEqual(format.sampleRate, sampleRate, 'format.sampleRate');

--- a/test/test-file-aiff.ts
+++ b/test/test-file-aiff.ts
@@ -15,14 +15,14 @@ describe('Parse AIFF (Audio Interchange File Format)', () => {
     const lossless = compressionType === 'PCM';
     const dataFormat = lossless ? 'AIFF' : 'AIFF-C';
     const duration = samples / format.sampleRate;
-    t.strictEqual(format.dataformat, dataFormat, `format.dataformat = '${dataFormat}'`);
+    t.strictEqual(format.container, dataFormat, `format.container = '${dataFormat}'`);
     t.strictEqual(format.lossless, lossless, `format.lossless = ${lossless}`);
     t.strictEqual(format.sampleRate, sampleRate, `format.sampleRate = ${sampleRate} kHz`);
     t.strictEqual(format.bitsPerSample, bitsPerSample, `format.bitsPerSample = ${bitsPerSample} bit`);
     t.strictEqual(format.numberOfChannels, channels, `format.numberOfChannels = ${channels} channels`);
     t.strictEqual(format.numberOfSamples, samples, `format.numberOfSamples = ${samples} samples`);
     t.strictEqual(format.duration, duration, `format.duration = ${duration} sec.`);
-    t.strictEqual(format.encoder, compressionType, `format.encoder = ${compressionType}`);
+    t.strictEqual(format.codec, compressionType, `format.codec = ${compressionType}`);
   }
 
   describe('Parse AIFF', () => {

--- a/test/test-file-asf.ts
+++ b/test/test-file-asf.ts
@@ -73,7 +73,7 @@ describe("Parse ASF", () => {
     const asfFilePath = path.join(__dirname, 'samples', 'asf.wma');
 
     function checkFormat(format) {
-      t.strictEqual(format.dataformat, 'ASF/audio', 'format.dataformat');
+      t.strictEqual(format.container, 'ASF/audio', 'format.container');
       t.strictEqual(format.duration, 244.885, 'format.duration');
       t.strictEqual(format.bitrate, 192639, 'format.bitrate');
     }

--- a/test/test-file-dsf.ts
+++ b/test/test-file-dsf.ts
@@ -13,7 +13,7 @@ describe('Parse Sony DSF (DSD Stream File)', () => {
     const metadata = await mm.parseFile(dsfFilePath, {duration: false});
 
     // format chunk information
-    assert.strictEqual(metadata.format.dataformat, 'DSF');
+    assert.strictEqual(metadata.format.container, 'DSF');
     assert.deepEqual(metadata.format.lossless, true);
     assert.deepEqual(metadata.format.numberOfChannels, 2);
     assert.deepEqual(metadata.format.bitsPerSample, 1);

--- a/test/test-file-flac.ts
+++ b/test/test-file-flac.ts
@@ -13,7 +13,7 @@ describe("Parse FLAC", () => {
   const flacFilePath = path.join(samplePath, "flac.flac");
 
   function checkFormat(format) {
-    t.strictEqual(format.dataformat, "flac", "format.dataformat");
+    t.strictEqual(format.container, "flac", "format.container");
     t.deepEqual(format.tagTypes, ["vorbis"], "format.tagTypes");
     t.strictEqual(format.duration, 271.7733333333333, "format.duration");
     t.strictEqual(format.sampleRate, 44100, "format.sampleRate = 44.1 kHz");

--- a/test/test-file-mp3.ts
+++ b/test/test-file-mp3.ts
@@ -34,8 +34,8 @@ describe("Parse MP3 files", () => {
 
     return mm.parseFile(filePath, {duration: true}).then(metadata => {
       const format = metadata.format;
-      assert.deepEqual(format.dataformat, 'MPEG', 'format.dataformat');
-      assert.deepEqual(format.encoder, 'mp3', 'format.encoder');
+      assert.deepEqual(format.container, 'MPEG', 'format.container');
+      assert.deepEqual(format.codec, 'mp3', 'format.codec');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
       assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
 
@@ -54,8 +54,8 @@ describe("Parse MP3 files", () => {
     function checkFormat(format: mm.IFormat) {
       t.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.tagTypes');
       t.approximately(format.duration, 61.73, 1 / 100, 'format.duration');
-      t.strictEqual(format.dataformat, 'MPEG', 'format.dataformat');
-      t.strictEqual(format.encoder, 'mp3', 'format.encoder');
+      t.strictEqual(format.container, 'MPEG', 'format.container');
+      t.strictEqual(format.codec, 'mp3', 'format.codec');
       t.strictEqual(format.lossless, false, 'format.lossless');
       t.strictEqual(format.sampleRate, 22050, 'format.sampleRate = 44.1 kHz');
       t.strictEqual(format.bitrate, 64000, 'format.bitrate = 128 kbit/sec');

--- a/test/test-file-mp4.ts
+++ b/test/test-file-mp4.ts
@@ -15,8 +15,8 @@ describe("Parse MPEG-4 files with iTunes metadata", () => {
 
     function checkFormat(format) {
       assert.deepEqual(format.lossless, false);
-      assert.deepEqual(format.dataformat, 'isom/M4A', 'dataformat');
-      assert.deepEqual(format.encoder, 'MP4A', 'encoder');
+      assert.deepEqual(format.container, 'isom/M4A', 'container');
+      assert.deepEqual(format.codec, 'MP4A', 'codec');
       assert.deepEqual(format.tagTypes, ['iTunes'], 'format.tagTypes');
       t.strictEqual(format.duration, 2.206, 'format.duration');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
@@ -150,8 +150,8 @@ describe("Parse MPEG-4 files with iTunes metadata", () => {
             assert.deepEqual(metadata.common.track, {no: null, of: null});
             assert.deepEqual(metadata.common.comment, ['Welcome to the long-awaited seventh novel of the best-selling saga by Aleron Kong, the longest and best book ever recorded by Nick Podehl!']);
 
-            assert.deepEqual(metadata.format.dataformat, 'iso2/isom', 'format.dataformat');
-            assert.deepEqual(metadata.format.encoder, 'MP4A+text', 'format.encoder');
+            assert.deepEqual(metadata.format.container, 'iso2/isom', 'format.container');
+            assert.deepEqual(metadata.format.codec, 'MP4A+text', 'format.codec');
           });
         });
       });
@@ -173,8 +173,8 @@ describe("Parse MPEG-4 files with iTunes metadata", () => {
             assert.deepEqual(metadata.common.track, {no: 1, of: null});
             assert.deepEqual(metadata.common.comment, ['https://archive.org/details/glories_of_ireland_1801_librivox']);
 
-            assert.deepEqual(metadata.format.dataformat, '3gp5/M4A', 'format.dataformat');
-            assert.deepEqual(metadata.format.encoder, 'MP4A+text', 'format.encoder');
+            assert.deepEqual(metadata.format.container, '3gp5/M4A', 'format.container');
+            assert.deepEqual(metadata.format.codec, 'MP4A+text', 'format.codec');
 
             const iTunes = mm.orderTags(metadata.native.iTunes);
             assert.deepEqual(iTunes.stik, [2], 'iTunes.stik = 2 = Audiobook'); // Ref: http://www.zoyinc.com/?p=1004
@@ -200,8 +200,8 @@ describe("Parse MPEG-4 files with iTunes metadata", () => {
             assert.deepEqual(metadata.common.tvSeason, 2);
             assert.deepEqual(metadata.common.tvShow, 'Mr. Pickles');
 
-            assert.deepEqual(metadata.format.dataformat, 'mp42', 'format.dataformat');
-            assert.deepEqual(metadata.format.encoder, 'MP4A+avc1+ac-3+CEA-608', 'format.encoder');
+            assert.deepEqual(metadata.format.container, 'mp42', 'format.container');
+            assert.deepEqual(metadata.format.codec, 'MP4A+avc1+ac-3+CEA-608', 'format.codec');
             assert.deepEqual(metadata.common.artist, 'Mr. Pickles');
             assert.deepEqual(metadata.common.artists, ['Mr. Pickles']);
             assert.deepEqual(metadata.common.albumartist, 'Mr. Pickles');
@@ -223,8 +223,8 @@ describe("Parse MPEG-4 files with iTunes metadata", () => {
         const filePath = path.join(mp4Samples, 'issue-133.m4a');
 
         return parser.initParser(filePath, 'audio/mp4', {duration: true, native: true}).then(metadata => {
-          assert.deepEqual(metadata.format.dataformat, 'mp42/M4A', 'format.dataformat');
-          assert.deepEqual(metadata.format.encoder, 'MP4A', 'format.encoder');
+          assert.deepEqual(metadata.format.container, 'mp42/M4A', 'format.container');
+          assert.deepEqual(metadata.format.codec, 'MP4A', 'format.codec');
         });
       });
     });
@@ -238,8 +238,8 @@ describe("Parse MPEG-4 files with iTunes metadata", () => {
         const filePath = path.join(mp4Samples, 'issue-151.m4a');
 
         return parser.initParser(filePath, 'audio/mp4', {duration: true, native: true}).then(metadata => {
-          assert.deepEqual(metadata.format.dataformat, 'mp42', 'format.dataformat');
-          assert.deepEqual(metadata.format.encoder, 'MP4A+MP4S', 'format.encoder');
+          assert.deepEqual(metadata.format.container, 'mp42', 'format.container');
+          assert.deepEqual(metadata.format.codec, 'MP4A+MP4S', 'format.codec');
 
           assert.deepEqual(metadata.common.album, 'We Don`t Need to Whisper');
           assert.deepEqual(metadata.common.albumartist, 'Angels and Airwaves');

--- a/test/test-file-mpeg.ts
+++ b/test/test-file-mpeg.ts
@@ -38,8 +38,8 @@ describe("Parse MPEG", () => {
     return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
 
       t.deepEqual(metadata.format.tagTypes, ["ID3v2.3", "ID3v1"], "Tags: ID3v1 & ID3v2.3");
-      t.strictEqual(metadata.format.dataformat, "MPEG", "format.dataformat = MPEG");
-      t.strictEqual(metadata.format.encoder, "mp2", "format.encoder = mp2 (MPEG-2 Audio Layer II)");
+      t.strictEqual(metadata.format.container, "MPEG", "format.container = MPEG");
+      t.strictEqual(metadata.format.codec, "mp2", "format.codec = mp2 (MPEG-2 Audio Layer II)");
       t.strictEqual(metadata.format.bitrate, 128000, "format.bitrate = 128 kbit/sec");
       t.strictEqual(metadata.format.sampleRate, 44100, "format.sampleRate = 44.1 kHz");
       t.strictEqual(metadata.format.numberOfSamples, 23040, "format.numberOfSamples = 23040");
@@ -97,7 +97,7 @@ describe("Parse MPEG", () => {
         t.strictEqual(format.bitrate, 320000, "format.bitrate = 128 kbit/sec");
         t.strictEqual(format.numberOfChannels, 2, "format.numberOfChannels 2 (stereo)");
 
-        // t.strictEqual(format.encoder, 'LAME3.91', 'format.encoder');
+        // t.strictEqual(format.codec, 'LAME3.91', 'format.codec');
         // t.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
       }
 
@@ -162,7 +162,7 @@ describe("Parse MPEG", () => {
         t.approximately(format.duration, 200.9, 1 / 10, "format.duration"); // FooBar says 3:26.329 seconds
         t.strictEqual(format.bitrate, 320000, "format.bitrate = 128 kbit/sec");
         t.strictEqual(format.numberOfChannels, 2, "format.numberOfChannels 2 (stereo)");
-        // t.strictEqual(format.encoder, 'LAME3.98r', 'format.encoder'); // 'LAME3.91' found on position 81BCF=531407// 'LAME3.91' found on position 81BCF=531407
+        // t.strictEqual(format.codec, 'LAME3.98r', 'format.codec'); // 'LAME3.91' found on position 81BCF=531407// 'LAME3.91' found on position 81BCF=531407
         // t.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
       }
 
@@ -250,8 +250,8 @@ describe("Parse MPEG", () => {
     function checkFormat(format: IFormat, expectedDuration) {
       t.deepEqual(format.tagTypes, ["ID3v2.3", "ID3v2.4", "ID3v1"], "format.tagTypes");
       t.strictEqual(format.duration, expectedDuration, "format.duration");
-      t.deepEqual(format.dataformat, 'MPEG', 'format.dataformat');
-      t.deepEqual(format.encoder, 'mp3', 'format.encoder');
+      t.deepEqual(format.container, 'MPEG', 'format.container');
+      t.deepEqual(format.codec, 'mp3', 'format.codec');
       t.strictEqual(format.lossless, false, "format.lossless");
       t.strictEqual(format.sampleRate, 44100, "format.sampleRate = 44.1 kHz");
       t.strictEqual(format.bitrate, 320000, "format.bitrate = 160 kbit/sec");

--- a/test/test-file-musepack.ts
+++ b/test/test-file-musepack.ts
@@ -16,11 +16,11 @@ describe('Parse Musepack (.mpc)', () => {
         return parser.initParser(filePath, 'audio/musepack', {native: true}).then(metadata => {
           // Check format
           const format = metadata.format;
-          assert.deepEqual(format.dataformat, 'Musepack, SV7');
+          assert.deepEqual(format.container, 'Musepack, SV7');
           assert.strictEqual(format.sampleRate, 44100);
           assert.strictEqual(format.numberOfSamples, 11940);
           assert.approximately(format.bitrate, 269649, 1);
-          assert.strictEqual(format.encoder, '1.15');
+          assert.strictEqual(format.codec, '1.15');
 
           // Check generic metadata
           const common = metadata.common;
@@ -51,11 +51,11 @@ describe('Parse Musepack (.mpc)', () => {
 
         return parser.initParser(filePath, 'audio/musepack', {native: true}).then(metadata => {
           // Check format
-          assert.deepEqual(metadata.format.dataformat, 'Musepack, SV7');
+          assert.deepEqual(metadata.format.container, 'Musepack, SV7');
           assert.strictEqual(metadata.format.sampleRate, 44100);
           assert.strictEqual(metadata.format.numberOfSamples, 11940);
           assert.approximately(metadata.format.bitrate, 269649, 1);
-          assert.strictEqual(metadata.format.encoder, '1.15');
+          assert.strictEqual(metadata.format.codec, '1.15');
 
           // Check generic metadata
           assert.strictEqual(metadata.common.title, 'God Inside');
@@ -78,7 +78,7 @@ describe('Parse Musepack (.mpc)', () => {
 
         return parser.initParser(filePath, 'audio/musepack', {native: true}).then(metadata => {
           // Check format
-          assert.deepEqual(metadata.format.dataformat, 'Musepack, SV8');
+          assert.deepEqual(metadata.format.container, 'Musepack, SV8');
           assert.strictEqual(metadata.format.sampleRate, 48000);
           assert.strictEqual(metadata.format.numberOfSamples, 24000);
           assert.strictEqual(metadata.format.numberOfChannels, 2);

--- a/test/test-file-ogg.ts
+++ b/test/test-file-ogg.ts
@@ -101,7 +101,7 @@ describe("Parse Ogg", function() {
       const filePath = path.join(samplePath, 'issue_70.ogg');
 
       return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
-        assert.strictEqual(metadata.format.dataformat, 'Ogg/Vorbis I');
+        assert.strictEqual(metadata.format.container, 'Ogg/Vorbis I');
         assert.strictEqual(metadata.format.sampleRate, 44100);
 
         const vorbis = mm.orderTags(metadata.native.vorbis);
@@ -165,8 +165,8 @@ describe("Parse Ogg", function() {
       const filePath = path.join(samplePath, 'female_scrub.spx');
 
       function checkFormat(format) {
-        assert.strictEqual(format.dataformat, 'Ogg/Speex', 'format.dataformat');
-        assert.strictEqual(format.encoder, '1.0beta1');
+        assert.strictEqual(format.container, 'Ogg/Speex', 'format.container');
+        assert.strictEqual(format.codec, '1.0beta1');
         assert.strictEqual(format.sampleRate, 8000, 'format.sampleRate = 8 kHz');
       }
 

--- a/test/test-file-riff.ts
+++ b/test/test-file-riff.ts
@@ -28,7 +28,7 @@ describe("Parse RIFF (Resource Interchange File Format)", () => {
       const filePath = path.join(samplePath, filename);
 
       function checkFormat(format: IFormat) {
-        assert.strictEqual(format.dataformat, "WAVE/PCM", "format.dataformat = WAVE/PCM");
+        assert.strictEqual(format.container, "WAVE/PCM", "format.container = WAVE/PCM");
         assert.strictEqual(format.lossless, true);
         assert.deepEqual(format.tagTypes, ['exif', 'ID3v2.3'], "format.tagTypes = ['exif', 'ID3v2.3']");
         assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
@@ -54,7 +54,7 @@ describe("Parse RIFF (Resource Interchange File Format)", () => {
       const filePath = path.join(samplePath, "issue_75.wav");
 
       return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
-        assert.deepEqual(metadata.format.dataformat, "WAVE/PCM");
+        assert.deepEqual(metadata.format.container, "WAVE/PCM");
       });
     });
 
@@ -66,7 +66,7 @@ describe("Parse RIFF (Resource Interchange File Format)", () => {
       return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
         const format = metadata.format;
         assert.strictEqual(format.lossless, true);
-        assert.deepEqual(format.dataformat, "WAVE/PCM");
+        assert.deepEqual(format.container, "WAVE/PCM");
         assert.deepEqual(format.bitsPerSample, 24);
         assert.deepEqual(format.sampleRate, 48000);
         assert.deepEqual(format.numberOfSamples, 13171);
@@ -113,7 +113,7 @@ describe("Parse RIFF (Resource Interchange File Format)", () => {
 
       return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
         const format = metadata.format;
-        assert.strictEqual(format.dataformat, "WAVE/PCM");
+        assert.strictEqual(format.container, "WAVE/PCM");
         assert.strictEqual(format.lossless, true);
         assert.strictEqual(format.sampleRate, 48000);
         assert.strictEqual(format.bitsPerSample, 24);
@@ -132,7 +132,7 @@ describe("Parse RIFF (Resource Interchange File Format)", () => {
 
       return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
         const format = metadata.format;
-        assert.strictEqual(format.dataformat, "WAVE/ADPCM");
+        assert.strictEqual(format.container, "WAVE/ADPCM");
         assert.strictEqual(format.lossless, false);
         assert.strictEqual(format.sampleRate, 22050);
         assert.strictEqual(format.bitsPerSample, 4);

--- a/test/test-file-wavpack.ts
+++ b/test/test-file-wavpack.ts
@@ -10,7 +10,7 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
   describe('codec: WavPack', () => {
 
     function checkFormat(format) {
-      t.strictEqual(format.dataformat, 'WavPack', 'format.dataformat');
+      t.strictEqual(format.container, 'WavPack', 'format.container');
       t.deepEqual(format.tagTypes, ['APEv2'], 'format.tagTypes');
       t.approximately(format.duration, 2.123, 1 / 1000, 'format.duration');
       t.strictEqual(format.codecProfile, 'PCM', 'format.codecProfile');
@@ -36,7 +36,7 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
   describe('codec: DSD128', () => {
 
     function checkFormat(format) {
-      t.strictEqual(format.dataformat, 'WavPack', 'format.dataformat');
+      t.strictEqual(format.container, 'WavPack', 'format.container');
       t.strictEqual(format.codecProfile, 'DSD', 'format.codecProfile');
       t.deepEqual(format.numberOfSamples, 564480, 'format.numberOfSamples');
       t.strictEqual(format.sampleRate, 5644800, 'format.sampleRate');
@@ -58,7 +58,7 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
   describe('codec: DSD128 compressed', () => {
 
     function checkFormat(format) {
-      t.strictEqual(format.dataformat, 'WavPack', 'format.dataformat');
+      t.strictEqual(format.container, 'WavPack', 'format.container');
       t.strictEqual(format.codecProfile, 'DSD', 'format.codecProfile');
       t.deepEqual(format.numberOfSamples, 564480, 'format.numberOfSamples');
       t.strictEqual(format.sampleRate, 5644800, 'format.sampleRate');

--- a/test/test-http.ts
+++ b/test/test-http.ts
@@ -81,7 +81,7 @@ describe.skip('HTTP streaming', function() {
             if (response.stream.destroy) {
               response.stream.destroy(); // Node >= v8 only
             }
-            assert.strictEqual(tags.format.encoder, 'MP4A');
+            assert.strictEqual(tags.format.codec, 'MP4A');
             assert.strictEqual(tags.format.lossless, false);
 
             assert.strictEqual(tags.common.title, 'We Made a Plan');

--- a/test/test-id3v1.1.ts
+++ b/test/test-id3v1.1.ts
@@ -15,8 +15,8 @@ describe("Parsing MPEG / ID3v1", () => {
 
     function checkFormat(format: IFormat) {
       t.deepEqual(format.tagTypes, ['ID3v1'], 'format.tagTypes');
-      t.strictEqual(format.dataformat, 'MPEG', 'format.dataformat');
-      t.strictEqual(format.encoder, 'mp3', 'format.encoder');
+      t.strictEqual(format.container, 'MPEG', 'format.container');
+      t.strictEqual(format.codec, 'mp3', 'format.codec');
       t.strictEqual(format.lossless, false, 'format.lossless');
       t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       t.strictEqual(format.bitrate, 160000, 'format.bitrate = 160 kbit/sec');
@@ -83,8 +83,8 @@ describe("Parsing MPEG / ID3v1", () => {
     function checkFormat(format: IFormat) {
       t.deepEqual(format.tagTypes, [], 'format.tagTypes');
       t.strictEqual(format.duration, 2.088, 'format.duration');
-      t.strictEqual(format.dataformat, 'MPEG', 'format.dataformat');
-      t.strictEqual(format.encoder, 'mp3', 'format.encoder');
+      t.strictEqual(format.container, 'MPEG', 'format.container');
+      t.strictEqual(format.codec, 'mp3', 'format.codec');
       t.strictEqual(format.lossless, false, 'format.lossless');
       t.strictEqual(format.sampleRate, 16000, 'format.sampleRate = 44.1 kHz');
       t.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 kbit/sec');
@@ -112,8 +112,8 @@ describe("Parsing MPEG / ID3v1", () => {
     function checkFormat(format: IFormat) {
       t.strictEqual(format.duration, 33.38448979591837, 'format.duration (checked with foobar)');
       t.deepEqual(format.tagTypes, ['ID3v1'], 'format.tagTypes');
-      t.deepEqual(format.dataformat, 'MPEG', 'format.dataformat');
-      t.deepEqual(format.encoder, 'mp3', 'format.encoder');
+      t.deepEqual(format.container, 'MPEG', 'format.container');
+      t.deepEqual(format.codec, 'mp3', 'format.codec');
       t.strictEqual(format.lossless, false, 'format.lossless');
       t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       // t.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 bit/sec');

--- a/test/test-id3v2-duration-allframes.ts
+++ b/test/test-id3v2-duration-allframes.ts
@@ -30,8 +30,8 @@ it("should decode id3v2-duration-allframes", () => {
     t.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
     t.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
     t.strictEqual(format.duration, 57 * 1152 / format.sampleRate, 'format.duration (test duration=true)');
-    t.strictEqual(format.dataformat, 'MPEG', 'format.dataformat');
-    t.strictEqual(format.encoder, 'mp3', 'format.encoder');
+    t.strictEqual(format.container, 'MPEG', 'format.container');
+    t.strictEqual(format.codec, 'mp3', 'format.codec');
     t.strictEqual(format.tool, 'LAME 3.98.4', 'format.tool');
   }
 

--- a/test/test-id3v2.3.ts
+++ b/test/test-id3v2.3.ts
@@ -38,8 +38,8 @@ describe("Extract metadata from ID3v2.3 header", () => {
       t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       t.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 kbit/sec');
       t.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels 2 (stereo)');
-      t.strictEqual(format.dataformat, 'MPEG', 'format.dataformat');
-      t.strictEqual(format.encoder, 'mp3', 'format.encoder');
+      t.strictEqual(format.container, 'MPEG', 'format.container');
+      t.strictEqual(format.codec, 'mp3', 'format.codec');
       t.strictEqual(format.tool, 'LAME3.98r', 'format.tool');
       t.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
     }
@@ -110,8 +110,8 @@ describe("Extract metadata from ID3v2.3 header", () => {
       function checkFormat(format: mm.IFormat) {
         t.strictEqual(format.duration, 247.84979591836733, 'format.duration');
         t.deepEqual(format.tagTypes, ['ID3v2.3'], 'format.tagTypes');
-        t.strictEqual(format.dataformat, 'MPEG', 'format.dataformat');
-        t.strictEqual(format.encoder, 'mp3', 'format.encoder');
+        t.strictEqual(format.container, 'MPEG', 'format.container');
+        t.strictEqual(format.codec, 'mp3', 'format.codec');
         t.strictEqual(format.lossless, false, 'format.lossless');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
         t.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 bit/sec');

--- a/test/test-id3v2.4.ts
+++ b/test/test-id3v2.4.ts
@@ -20,8 +20,8 @@ describe("Decode MP3/ID3v2.4", () => {
       t.strictEqual(metadata.format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       t.strictEqual(metadata.format.bitrate, 128000, 'format.bitrate = 128 kbit/sec');
       t.strictEqual(metadata.format.codecProfile, 'CBR', 'format.codecProfile = CBR');
-      t.strictEqual(metadata.format.dataformat, 'MPEG', 'format.dataformat');
-      t.strictEqual(metadata.format.encoder, 'mp3', 'format.encoder');
+      t.strictEqual(metadata.format.container, 'MPEG', 'format.container');
+      t.strictEqual(metadata.format.codec, 'mp3', 'format.codec');
       t.strictEqual(metadata.format.tool, 'LAME3.98r', 'format.tool');
       t.strictEqual(metadata.format.numberOfChannels, 2, 'format.numberOfChannels = 2');
 

--- a/test/test-mime.ts
+++ b/test/test-mime.ts
@@ -83,7 +83,7 @@ describe("MIME & extension mapping", () => {
     const stream = fs.createReadStream(path.join(samplePath, "MusicBrainz - Beth Hart - Sinner's Prayer [id3v2.3].wav"));
     return mm.parseStream(stream, '').then(metadata => {
       stream.close();
-      assert.equal(metadata.format.dataformat, "WAVE/PCM");
+      assert.equal(metadata.format.container, "WAVE/PCM");
     });
 
   });
@@ -115,11 +115,11 @@ describe("MIME & extension mapping", () => {
         });
     });
 
-    async function testFileType(sample: string, dataformat: string) {
+    async function testFileType(sample: string, container: string) {
       const stream = fs.createReadStream(path.join(samplePath, sample));
       const metadata = await mm.parseStream(stream);
       stream.close();
-      assert.equal(metadata.format.dataformat, dataformat);
+      assert.equal(metadata.format.container, container);
     }
 
     it("should recognize MP2", () => {

--- a/test/test-picard-parsing.ts
+++ b/test/test-picard-parsing.ts
@@ -143,7 +143,7 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
      * Check native Vorbis header
      * @param vorbis Vorbis native tags
      */
-    function checkVorbisTags(vorbis: INativeTagDict, dataformat: string) {
+    function checkVorbisTags(vorbis: INativeTagDict, container: string) {
       // Compare expectedCommonTags with result.common
       t.deepEqual(vorbis.TITLE, ['Sinner\'s Prayer'], 'vorbis.TITLE');
       t.deepEqual(vorbis.ALBUM, ['Don\'t Explain'], 'vorbis.TITLE');
@@ -190,7 +190,7 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
       const filename = "MusicBrainz - Beth Hart - Sinner's Prayer.flac";
 
       function checkFormat(format) {
-        t.strictEqual(format.dataformat, "flac", "format.dataformat = 'flac'");
+        t.strictEqual(format.container, "flac", "format.container = 'flac'");
         t.strictEqual(format.duration, 2.1229931972789116, 'format.duration = 2.123 seconds');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44100 samples/sec');
         t.strictEqual(format.bitsPerSample, 16, 'format.bitsPerSample = 16 bits');
@@ -201,7 +201,7 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
       return mm.parseFile(path.join(samplePath, filename), {native: true}).then(result => {
         t.ok(result.native && result.native.vorbis, 'should include native Vorbis tags');
         checkFormat(result.format);
-        checkVorbisTags(mm.orderTags(result.native.vorbis), result.format.dataformat);
+        checkVorbisTags(mm.orderTags(result.native.vorbis), result.format.container);
         checkCommonMapping('vorbis', result.common);
       });
 
@@ -215,7 +215,7 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
       return mm.parseFile(filePath, {native: true}).then(result => {
         t.ok(result.native && result.native.vorbis, 'should include native Vorbis tags');
         // Check Vorbis native tags
-        checkVorbisTags(mm.orderTags(result.native.vorbis), result.format.dataformat);
+        checkVorbisTags(mm.orderTags(result.native.vorbis), result.format.container);
         // Check common mappings
         checkCommonMapping('vorbis', result.common);
       });
@@ -380,8 +380,8 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
 
       function checkFormat(format) {
         t.deepEqual(format.tagTypes, ['ID3v2.3'], 'format.tagTypes');
-        t.deepEqual(format.dataformat, 'MPEG', 'format.dataformat');
-        t.deepEqual(format.encoder, 'mp3', 'format.encoder');
+        t.deepEqual(format.container, 'MPEG', 'format.container');
+        t.deepEqual(format.codec, 'mp3', 'format.codec');
         t.strictEqual(format.duration, 2.1681632653061222, 'format.duration');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
         t.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
@@ -408,7 +408,7 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
       const filePath = path.join(samplePath, "MusicBrainz - Beth Hart - Sinner's Prayer [id3v2.3].wav");
 
       function checkFormat(format: IFormat) {
-        // t.strictEqual(format.dataformat, "WAVE", "format.dataformat = WAVE PCM");
+        // t.strictEqual(format.container, "WAVE", "format.container = WAVE PCM");
         t.deepEqual(format.tagTypes, ['exif', 'ID3v2.3'], 'format.tagTypes)');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
         t.strictEqual(format.bitsPerSample, 16, 'format.bitsPerSample = 16 bits');
@@ -500,8 +500,8 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
 
       function checkFormat(format: IFormat) {
         t.deepEqual(format.tagTypes, ['ID3v2.4'], 'format.tagTypes');
-        t.strictEqual(format.dataformat, 'MPEG', 'format.dataformat');
-        t.strictEqual(format.encoder, 'mp3', 'format.encoder');
+        t.strictEqual(format.container, 'MPEG', 'format.container');
+        t.strictEqual(format.codec, 'mp3', 'format.codec');
         t.strictEqual(format.codecProfile, 'V2', 'format.codecProfile = V2');
         t.strictEqual(format.tool, 'LAME3.99r', 'format.tool');
         t.strictEqual(format.duration, 2.1681632653061222, 'format.duration');
@@ -524,7 +524,7 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
       const filePath = path.join(samplePath, "MusicBrainz - Beth Hart - Sinner's Prayer [id3v2.4].aiff");
 
       function checkFormat(format: IFormat) {
-        t.strictEqual(format.dataformat, "AIFF", "format.dataformat = 'AIFF'");
+        t.strictEqual(format.container, "AIFF", "format.container = 'AIFF'");
         t.deepEqual(format.tagTypes, ["ID3v2.4"], "format.tagTypes = 'ID3v2.4'"); // ToDo
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
         t.strictEqual(format.bitsPerSample, 16, 'format.bitsPerSample = 16 bits');
@@ -554,8 +554,8 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
 
     function checkFormat(format: IFormat) {
       t.deepEqual(format.tagTypes, ['iTunes'], 'format.tagTypes');
-      t.strictEqual(format.dataformat, 'isom/mp42/M4A', 'format.dataformat');
-      t.strictEqual(format.encoder, 'ALAC', 'format.encoder');
+      t.strictEqual(format.container, 'isom/mp42/M4A', 'format.container');
+      t.strictEqual(format.codec, 'ALAC', 'format.codec');
       t.strictEqual(format.lossless, true, 'ALAC is a lossless format');
       t.strictEqual(format.duration, 2.1229931972789116, 'format.duration');
       t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
@@ -608,7 +608,7 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
     function checkFormat(format: IFormat) {
       t.deepEqual(format.tagTypes, ["asf"], "format.tagTypes = asf");
       t.strictEqual(format.bitrate, 320000, "format.bitrate = 320000");
-      // ToDo t.strictEqual(format.dataformat, "wma", "format.dataformat = wma");
+      // ToDo t.strictEqual(format.container, "wma", "format.container = wma");
       t.strictEqual(format.duration, 5.235, 'format.duration'); // duration is wrong, but seems to be what is written in file
       // ToDo t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       // ToDo t.strictEqual(format.bitsPerSample, 16, 'format.bitsPerSample'); // ToDo


### PR DESCRIPTION
| New property name  | Old Property name   |
| -------------------|---------------------|
| `format.container` | `format.dataformat` |
| `format.codec`     | `format.encoder`    |