### PR TITLE
Update media-typer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,9 +68,10 @@
     "doc-gen": "node doc-gen/gen.js"
   },
   "dependencies": {
+    "content-type": "^1.0.4",
     "debug": "^4.1.0",
     "file-type": "^11.0.0",
-    "media-typer": "0.3.0",
+    "media-typer": "^1.1.0",
     "strtok3": "^2.3.0",
     "token-types": "^1.0.1"
   },

--- a/src/ParserFactory.ts
+++ b/src/ParserFactory.ts
@@ -1,6 +1,7 @@
 import {INativeAudioMetadata, IOptions, IAudioMetadata, ParserType} from "./type";
 import {ITokenizer} from "strtok3/lib/type";
 import * as fileType from "file-type";
+import * as ContentType from "content-type";
 import * as MimeType from "media-typer";
 
 import * as _debug from "debug";
@@ -36,6 +37,17 @@ export interface ITokenParser {
    * @returns {Promise<void>}
    */
   parse(): Promise<void>;
+}
+
+export function parseHttpContentType(contentType: string): {type: string, subtype: string, suffix?: string, parameters: { [id: string]: string; }} {
+  const type = ContentType.parse(contentType);
+  const mime = MimeType.parse(type.type);
+  return {
+    type: mime.type,
+    subtype: mime.subtype,
+    suffix: mime.suffix,
+    parameters: type.parameters
+  };
 }
 
 export class ParserFactory {
@@ -176,16 +188,16 @@ export class ParserFactory {
   }
 
   /**
-   * @param {string} mimeType MIME-Type, extension, path or filename
+   * @param {string} httpContentType HTTP Content-Type, extension, path or filename
    * @returns {string} Parser sub-module name
    */
-  private static getParserIdForMimeType(mimeType: string): ParserType {
+  private static getParserIdForMimeType(httpContentType: string): ParserType {
 
     let mime;
     try {
-      mime = MimeType.parse(mimeType);
+      mime = parseHttpContentType(httpContentType);
     } catch (err) {
-      debug(`Invalid MIME-type: ${mimeType}`);
+      debug(`Invalid HTTP Content-Type header value: ${httpContentType}`);
       return;
     }
 

--- a/test/test-common.ts
+++ b/test/test-common.ts
@@ -4,9 +4,9 @@ import {CommonTagMapper} from "../src/common/GenericTagMapper";
 import {commonTags, isSingleton} from "../src/common/GenericTagTypes";
 import * as path from "path";
 import * as mm from "../src";
-import * as MimeType from "media-typer";
 import {CombinedTagMapper} from "../src/common/CombinedTagMapper";
 import {joinArtists} from '../src/common/MetadataCollector';
+import { ParserFactory, parseHttpContentType } from '../src/ParserFactory';
 
 const t = assert;
 
@@ -98,21 +98,21 @@ describe("Convert rating", () => {
 describe("MimeType", () => {
 
   it('should be able to decode basic MIME-types', () => {
-    const mime = MimeType.parse('audio/mpeg');
+    const mime = parseHttpContentType('audio/mpeg');
     assert.equal(mime.type, 'audio');
     assert.equal(mime.subtype, 'mpeg');
   });
 
   it('should be able to decode MIME-type parameters', () => {
     {
-      const mime = MimeType.parse('message/external-body; access-type=URL');
+      const mime = parseHttpContentType('message/external-body; access-type=URL');
       assert.equal(mime.type, 'message');
       assert.equal(mime.subtype, 'external-body');
       assert.deepEqual(mime.parameters, {'access-type': 'URL'});
     }
 
     {
-      const mime = MimeType.parse('Text/HTML;Charset="utf-8"');
+      const mime = parseHttpContentType('Text/HTML;Charset="utf-8"');
       assert.equal(mime.type, 'text');
       assert.equal(mime.subtype, 'html');
       assert.deepEqual(mime.parameters, {charset: 'utf-8'});
@@ -120,7 +120,7 @@ describe("MimeType", () => {
   });
 
   it('should be able to decode MIME-type suffix', () => {
-    const mime = MimeType.parse('application/xhtml+xml');
+    const mime = parseHttpContentType('application/xhtml+xml');
     assert.equal(mime.type, 'application');
     assert.equal(mime.subtype, 'xhtml');
     assert.equal(mime.suffix, 'xml');

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,6 +672,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+content-type@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+
 convert-source-map@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
@@ -2179,9 +2183,9 @@ mdast-util-to-string@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.0.5.tgz#3552b05428af22ceda34f156afe62ec8e6d731ca"
 
-media-typer@0.3.0:
-  version "0.3.0"
-  resolved "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+media-typer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
 
 mem@^4.0.0:
   version "4.3.0"


### PR DESCRIPTION
Address issue #155

Used workaround to have the media-typer version 0.3.0 compliant result, using [file-type](https://github.com/jshttp/file-type) to for the first parsing of the HTTP content-type and [media-typer](https://github.com/jshttp/media-typer) to retrieve the type/sub-type.

```TypeScript
function parseHttpContentType(contentType: string): {type: string, subtype: string, suffix?: string, parameters: { [id: string]: string; }} {
  const type = ContentType.parse(contentType);
  const mime = MimeType.parse(type.type);
  return {
    type: mime.type,
    subtype: mime.subtype,
    suffix: mime.suffix,
    parameters: type.parameters
  };
}
```

Related: jshttp/media-typer#8