### PR TITLE
Update container/codec reporting

### DIFF
--- a/src/flac/FlacParser.ts
+++ b/src/flac/FlacParser.ts
@@ -92,7 +92,8 @@ export class FlacParser extends AbstractID3Parser {
       throw new Error('Unexpected block-stream-info length');
 
     const streamInfo = await this.tokenizer.readToken<IBlockStreamInfo>(Metadata.BlockStreamInfo);
-    this.metadata.setFormat('container', 'flac');
+    this.metadata.setFormat('container', 'FLAC');
+    this.metadata.setFormat('codec', 'FLAC');
     this.metadata.setFormat('lossless', true);
     this.metadata.setFormat('numberOfChannels', streamInfo.channels);
     this.metadata.setFormat('bitsPerSample', streamInfo.bitsPerSample);

--- a/src/mp4/MP4Parser.ts
+++ b/src/mp4/MP4Parser.ts
@@ -96,7 +96,8 @@ export class MP4Parser extends BasicParser {
         case "ftyp":
           const types = await this.parseAtom_ftyp(atom.dataLen);
           debug(`ftyp: ${types.join('/')}`);
-          this.metadata.setFormat('container', types.filter(distinct).join('/'));
+          const x = types.filter(distinct).join('/');
+          this.metadata.setFormat('container', x);
           return;
 
         case 'mdhd': // Media header atom

--- a/src/mpeg/MpegParser.ts
+++ b/src/mpeg/MpegParser.ts
@@ -211,7 +211,7 @@ class MpegFrameHeader {
     this.version = MpegFrameHeader.VersionID[this.versionIndex];
     this.channelMode = MpegFrameHeader.ChannelMode[this.channelModeIndex];
 
-    this.codec = 'mp' + this.layer;
+    this.codec = 'MP' + this.layer;
 
     // Calculate bitrate
     const bitrateInKbps = this.calcBitrate();

--- a/src/riff/WaveParser.ts
+++ b/src/riff/WaveParser.ts
@@ -82,7 +82,7 @@ export class WaveParser extends BasicParser {
             debug('WAVE/non-PCM format=' + fmt.wFormatTag);
             subFormat = 'non-PCM (' + fmt.wFormatTag + ')';
           }
-          this.metadata.setFormat('container', 'WAVE/' + subFormat);
+          this.metadata.setFormat('codec', subFormat);
           this.metadata.setFormat('bitsPerSample', fmt.wBitsPerSample);
           this.metadata.setFormat('sampleRate', fmt.nSamplesPerSec);
           this.metadata.setFormat('numberOfChannels', fmt.nChannels);

--- a/src/wavpack/WavPackParser.ts
+++ b/src/wavpack/WavPackParser.ts
@@ -51,7 +51,7 @@ export class WavPackParser extends BasicParser {
         }
         this.metadata.setFormat('numberOfChannels', header.flags.isMono ? 1 : 2);
         this.metadata.setFormat('numberOfSamples', header.totalSamples);
-        this.metadata.setFormat('codecProfile', header.flags.isDSD ? 'DSD' : 'PCM');
+        this.metadata.setFormat('codec', header.flags.isDSD ? 'DSD' : 'PCM');
       }
 
       const ignoreBytes = header.blockSize - (WavPack.BlockHeaderToken.len - 8);

--- a/test/test-async.ts
+++ b/test/test-async.ts
@@ -28,7 +28,12 @@ describe("Asynchronous observer updates", () => {
           {
             id: 'container',
             type: 'format',
-            value: 'flac'
+            value: 'FLAC'
+          },
+          {
+            id: 'codec',
+            type: 'format',
+            value: 'FLAC'
           },
           {
             id: 'lossless',

--- a/test/test-file-flac.ts
+++ b/test/test-file-flac.ts
@@ -13,7 +13,8 @@ describe("Parse FLAC", () => {
   const flacFilePath = path.join(samplePath, "flac.flac");
 
   function checkFormat(format) {
-    t.strictEqual(format.container, "flac", "format.container");
+    t.strictEqual(format.container, 'FLAC', "format.container");
+    t.strictEqual(format.codec, 'FLAC', "format.codec");
     t.deepEqual(format.tagTypes, ["vorbis"], "format.tagTypes");
     t.strictEqual(format.duration, 271.7733333333333, "format.duration");
     t.strictEqual(format.sampleRate, 44100, "format.sampleRate = 44.1 kHz");

--- a/test/test-file-mp3.ts
+++ b/test/test-file-mp3.ts
@@ -35,7 +35,7 @@ describe("Parse MP3 files", () => {
     return mm.parseFile(filePath, {duration: true}).then(metadata => {
       const format = metadata.format;
       assert.deepEqual(format.container, 'MPEG', 'format.container');
-      assert.deepEqual(format.codec, 'mp3', 'format.codec');
+      assert.deepEqual(format.codec, 'MP3', 'format.codec');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
       assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
 
@@ -55,7 +55,7 @@ describe("Parse MP3 files", () => {
       t.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.tagTypes');
       t.approximately(format.duration, 61.73, 1 / 100, 'format.duration');
       t.strictEqual(format.container, 'MPEG', 'format.container');
-      t.strictEqual(format.codec, 'mp3', 'format.codec');
+      t.strictEqual(format.codec, 'MP3', 'format.codec');
       t.strictEqual(format.lossless, false, 'format.lossless');
       t.strictEqual(format.sampleRate, 22050, 'format.sampleRate = 44.1 kHz');
       t.strictEqual(format.bitrate, 64000, 'format.bitrate = 128 kbit/sec');

--- a/test/test-file-mpeg.ts
+++ b/test/test-file-mpeg.ts
@@ -39,7 +39,7 @@ describe("Parse MPEG", () => {
 
       t.deepEqual(metadata.format.tagTypes, ["ID3v2.3", "ID3v1"], "Tags: ID3v1 & ID3v2.3");
       t.strictEqual(metadata.format.container, "MPEG", "format.container = MPEG");
-      t.strictEqual(metadata.format.codec, "mp2", "format.codec = mp2 (MPEG-2 Audio Layer II)");
+      t.strictEqual(metadata.format.codec, "MP2", "format.codec = mp2 (MPEG-2 Audio Layer II)");
       t.strictEqual(metadata.format.bitrate, 128000, "format.bitrate = 128 kbit/sec");
       t.strictEqual(metadata.format.sampleRate, 44100, "format.sampleRate = 44.1 kHz");
       t.strictEqual(metadata.format.numberOfSamples, 23040, "format.numberOfSamples = 23040");
@@ -251,7 +251,7 @@ describe("Parse MPEG", () => {
       t.deepEqual(format.tagTypes, ["ID3v2.3", "ID3v2.4", "ID3v1"], "format.tagTypes");
       t.strictEqual(format.duration, expectedDuration, "format.duration");
       t.deepEqual(format.container, 'MPEG', 'format.container');
-      t.deepEqual(format.codec, 'mp3', 'format.codec');
+      t.deepEqual(format.codec, 'MP3', 'format.codec');
       t.strictEqual(format.lossless, false, "format.lossless");
       t.strictEqual(format.sampleRate, 44100, "format.sampleRate = 44.1 kHz");
       t.strictEqual(format.bitrate, 320000, "format.bitrate = 160 kbit/sec");

--- a/test/test-file-riff.ts
+++ b/test/test-file-riff.ts
@@ -28,7 +28,8 @@ describe("Parse RIFF (Resource Interchange File Format)", () => {
       const filePath = path.join(samplePath, filename);
 
       function checkFormat(format: IFormat) {
-        assert.strictEqual(format.container, "WAVE/PCM", "format.container = WAVE/PCM");
+        assert.deepEqual(format.container, 'WAVE', 'format.container');
+        assert.deepEqual(format.codec, 'PCM', 'format.codec');
         assert.strictEqual(format.lossless, true);
         assert.deepEqual(format.tagTypes, ['exif', 'ID3v2.3'], "format.tagTypes = ['exif', 'ID3v2.3']");
         assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
@@ -54,7 +55,8 @@ describe("Parse RIFF (Resource Interchange File Format)", () => {
       const filePath = path.join(samplePath, "issue_75.wav");
 
       return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
-        assert.deepEqual(metadata.format.container, "WAVE/PCM");
+        assert.deepEqual(metadata.format.container, 'WAVE', 'format.container');
+        assert.deepEqual(metadata.format.codec, 'PCM', 'format.codec');
       });
     });
 
@@ -66,7 +68,8 @@ describe("Parse RIFF (Resource Interchange File Format)", () => {
       return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
         const format = metadata.format;
         assert.strictEqual(format.lossless, true);
-        assert.deepEqual(format.container, "WAVE/PCM");
+        assert.deepEqual(format.container, 'WAVE', 'format.container');
+        assert.deepEqual(format.codec, 'PCM', 'format.codec');
         assert.deepEqual(format.bitsPerSample, 24);
         assert.deepEqual(format.sampleRate, 48000);
         assert.deepEqual(format.numberOfSamples, 13171);
@@ -113,7 +116,8 @@ describe("Parse RIFF (Resource Interchange File Format)", () => {
 
       return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
         const format = metadata.format;
-        assert.strictEqual(format.container, "WAVE/PCM");
+        assert.strictEqual(format.container, 'WAVE', 'format.container');
+        assert.strictEqual(format.codec, 'PCM', 'format.codec');
         assert.strictEqual(format.lossless, true);
         assert.strictEqual(format.sampleRate, 48000);
         assert.strictEqual(format.bitsPerSample, 24);
@@ -132,7 +136,8 @@ describe("Parse RIFF (Resource Interchange File Format)", () => {
 
       return mm.parseFile(filePath, {duration: true, native: true}).then(metadata => {
         const format = metadata.format;
-        assert.strictEqual(format.container, "WAVE/ADPCM");
+        assert.strictEqual(format.container, 'WAVE', 'format.container');
+        assert.strictEqual(format.codec, 'ADPCM', 'format.codec');
         assert.strictEqual(format.lossless, false);
         assert.strictEqual(format.sampleRate, 22050);
         assert.strictEqual(format.bitsPerSample, 4);

--- a/test/test-file-wavpack.ts
+++ b/test/test-file-wavpack.ts
@@ -13,7 +13,7 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
       t.strictEqual(format.container, 'WavPack', 'format.container');
       t.deepEqual(format.tagTypes, ['APEv2'], 'format.tagTypes');
       t.approximately(format.duration, 2.123, 1 / 1000, 'format.duration');
-      t.strictEqual(format.codecProfile, 'PCM', 'format.codecProfile');
+      t.strictEqual(format.codec, 'PCM', 'format.codecProfile');
     }
 
     function checkCommon(common) {
@@ -37,7 +37,7 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
     function checkFormat(format) {
       t.strictEqual(format.container, 'WavPack', 'format.container');
-      t.strictEqual(format.codecProfile, 'DSD', 'format.codecProfile');
+      t.strictEqual(format.codec, 'DSD', 'format.codecProfile');
       t.deepEqual(format.numberOfSamples, 564480, 'format.numberOfSamples');
       t.strictEqual(format.sampleRate, 5644800, 'format.sampleRate');
       t.strictEqual(format.duration, 0.1, 'format.duration');
@@ -59,7 +59,7 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
     function checkFormat(format) {
       t.strictEqual(format.container, 'WavPack', 'format.container');
-      t.strictEqual(format.codecProfile, 'DSD', 'format.codecProfile');
+      t.strictEqual(format.codec, 'DSD', 'format.codecProfile');
       t.deepEqual(format.numberOfSamples, 564480, 'format.numberOfSamples');
       t.strictEqual(format.sampleRate, 5644800, 'format.sampleRate');
       t.strictEqual(format.duration, 0.1, 'format.duration');

--- a/test/test-id3v1.1.ts
+++ b/test/test-id3v1.1.ts
@@ -16,7 +16,7 @@ describe("Parsing MPEG / ID3v1", () => {
     function checkFormat(format: IFormat) {
       t.deepEqual(format.tagTypes, ['ID3v1'], 'format.tagTypes');
       t.strictEqual(format.container, 'MPEG', 'format.container');
-      t.strictEqual(format.codec, 'mp3', 'format.codec');
+      t.strictEqual(format.codec, 'MP3', 'format.codec');
       t.strictEqual(format.lossless, false, 'format.lossless');
       t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       t.strictEqual(format.bitrate, 160000, 'format.bitrate = 160 kbit/sec');
@@ -84,7 +84,7 @@ describe("Parsing MPEG / ID3v1", () => {
       t.deepEqual(format.tagTypes, [], 'format.tagTypes');
       t.strictEqual(format.duration, 2.088, 'format.duration');
       t.strictEqual(format.container, 'MPEG', 'format.container');
-      t.strictEqual(format.codec, 'mp3', 'format.codec');
+      t.strictEqual(format.codec, 'MP3', 'format.codec');
       t.strictEqual(format.lossless, false, 'format.lossless');
       t.strictEqual(format.sampleRate, 16000, 'format.sampleRate = 44.1 kHz');
       t.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 kbit/sec');
@@ -113,7 +113,7 @@ describe("Parsing MPEG / ID3v1", () => {
       t.strictEqual(format.duration, 33.38448979591837, 'format.duration (checked with foobar)');
       t.deepEqual(format.tagTypes, ['ID3v1'], 'format.tagTypes');
       t.deepEqual(format.container, 'MPEG', 'format.container');
-      t.deepEqual(format.codec, 'mp3', 'format.codec');
+      t.deepEqual(format.codec, 'MP3', 'format.codec');
       t.strictEqual(format.lossless, false, 'format.lossless');
       t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       // t.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 bit/sec');

--- a/test/test-id3v2-duration-allframes.ts
+++ b/test/test-id3v2-duration-allframes.ts
@@ -31,7 +31,7 @@ it("should decode id3v2-duration-allframes", () => {
     t.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
     t.strictEqual(format.duration, 57 * 1152 / format.sampleRate, 'format.duration (test duration=true)');
     t.strictEqual(format.container, 'MPEG', 'format.container');
-    t.strictEqual(format.codec, 'mp3', 'format.codec');
+    t.strictEqual(format.codec, 'MP3', 'format.codec');
     t.strictEqual(format.tool, 'LAME 3.98.4', 'format.tool');
   }
 

--- a/test/test-id3v2.3.ts
+++ b/test/test-id3v2.3.ts
@@ -39,7 +39,7 @@ describe("Extract metadata from ID3v2.3 header", () => {
       t.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 kbit/sec');
       t.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels 2 (stereo)');
       t.strictEqual(format.container, 'MPEG', 'format.container');
-      t.strictEqual(format.codec, 'mp3', 'format.codec');
+      t.strictEqual(format.codec, 'MP3', 'format.codec');
       t.strictEqual(format.tool, 'LAME3.98r', 'format.tool');
       t.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
     }
@@ -111,7 +111,7 @@ describe("Extract metadata from ID3v2.3 header", () => {
         t.strictEqual(format.duration, 247.84979591836733, 'format.duration');
         t.deepEqual(format.tagTypes, ['ID3v2.3'], 'format.tagTypes');
         t.strictEqual(format.container, 'MPEG', 'format.container');
-        t.strictEqual(format.codec, 'mp3', 'format.codec');
+        t.strictEqual(format.codec, 'MP3', 'format.codec');
         t.strictEqual(format.lossless, false, 'format.lossless');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
         t.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 bit/sec');

--- a/test/test-id3v2.4.ts
+++ b/test/test-id3v2.4.ts
@@ -21,7 +21,7 @@ describe("Decode MP3/ID3v2.4", () => {
       t.strictEqual(metadata.format.bitrate, 128000, 'format.bitrate = 128 kbit/sec');
       t.strictEqual(metadata.format.codecProfile, 'CBR', 'format.codecProfile = CBR');
       t.strictEqual(metadata.format.container, 'MPEG', 'format.container');
-      t.strictEqual(metadata.format.codec, 'mp3', 'format.codec');
+      t.strictEqual(metadata.format.codec, 'MP3', 'format.codec');
       t.strictEqual(metadata.format.tool, 'LAME3.98r', 'format.tool');
       t.strictEqual(metadata.format.numberOfChannels, 2, 'format.numberOfChannels = 2');
 

--- a/test/test-mime.ts
+++ b/test/test-mime.ts
@@ -83,7 +83,7 @@ describe("MIME & extension mapping", () => {
     const stream = fs.createReadStream(path.join(samplePath, "MusicBrainz - Beth Hart - Sinner's Prayer [id3v2.3].wav"));
     return mm.parseStream(stream, '').then(metadata => {
       stream.close();
-      assert.equal(metadata.format.container, "WAVE/PCM");
+      assert.equal(metadata.format.container, 'WAVE');
     });
 
   });
@@ -144,7 +144,7 @@ describe("MIME & extension mapping", () => {
     });
 
     it("should recognize FLAC", () => {
-      return testFileType('flac.flac', 'flac');
+      return testFileType('flac.flac', 'FLAC');
     });
 
     it("should recognize OGG", () => {
@@ -152,7 +152,7 @@ describe("MIME & extension mapping", () => {
     });
 
     it("should recognize WAV", () => {
-      return testFileType("MusicBrainz - Beth Hart - Sinner's Prayer [id3v2.3].wav", 'WAVE/PCM');
+      return testFileType("MusicBrainz - Beth Hart - Sinner's Prayer [id3v2.3].wav", 'WAVE');
     });
 
     it("should recognize APE", () => {

--- a/test/test-picard-parsing.ts
+++ b/test/test-picard-parsing.ts
@@ -190,7 +190,8 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
       const filename = "MusicBrainz - Beth Hart - Sinner's Prayer.flac";
 
       function checkFormat(format) {
-        t.strictEqual(format.container, "flac", "format.container = 'flac'");
+        t.strictEqual(format.container, 'FLAC', 'format.container');
+        t.strictEqual(format.codec, 'FLAC', 'format.codec');
         t.strictEqual(format.duration, 2.1229931972789116, 'format.duration = 2.123 seconds');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44100 samples/sec');
         t.strictEqual(format.bitsPerSample, 16, 'format.bitsPerSample = 16 bits');
@@ -381,7 +382,7 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
       function checkFormat(format) {
         t.deepEqual(format.tagTypes, ['ID3v2.3'], 'format.tagTypes');
         t.deepEqual(format.container, 'MPEG', 'format.container');
-        t.deepEqual(format.codec, 'mp3', 'format.codec');
+        t.deepEqual(format.codec, 'MP3', 'format.codec');
         t.strictEqual(format.duration, 2.1681632653061222, 'format.duration');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
         t.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
@@ -501,7 +502,7 @@ describe("Parsing of metadata saved by 'Picard' in audio files", () => {
       function checkFormat(format: IFormat) {
         t.deepEqual(format.tagTypes, ['ID3v2.4'], 'format.tagTypes');
         t.strictEqual(format.container, 'MPEG', 'format.container');
-        t.strictEqual(format.codec, 'mp3', 'format.codec');
+        t.strictEqual(format.codec, 'MP3', 'format.codec');
         t.strictEqual(format.codecProfile, 'V2', 'format.codecProfile = V2');
         t.strictEqual(format.tool, 'LAME3.99r', 'format.tool');
         t.strictEqual(format.duration, 2.1681632653061222, 'format.duration');


### PR DESCRIPTION
Following formats:

| Format       | container  | codec |
|--------------|------------|-------| 
| FLAC         | FLAC       |       |
| MP3          | MPEG       | mp3   |   
| PCM - WAVE   | WAVE/PCM   |       |
| ADPCM - WAVE | WAVE/ADPCM |       |  


are reported like this with this PR:

| Format       | container | codec |
|--------------|-----------|-------| 
| FLAC         | FLAC      | FLAC  |
| MP3          | MPEG      | MP3   |   
| PCM - WAVE   | WAVE      | PCM   |
| ADPCM - WAVE | WAVE      | ADPCM |  

