### PR TITLE
Fix bit/rate calculation

### DIFF
--- a/src/iff/index.ts
+++ b/src/iff/index.ts
@@ -1,5 +1,4 @@
 import * as Token from "token-types";
-import * as assert from "assert";
 import {FourCcToken} from "../common/FourCC";
 
 /**

--- a/src/mp4/MP4Parser.ts
+++ b/src/mp4/MP4Parser.ts
@@ -5,7 +5,6 @@ import {BasicParser} from '../common/BasicParser';
 import {Atom} from './Atom';
 import * as AtomToken from './AtomToken';
 import {Genres} from '../id3v1/ID3v1Parser';
-import util from '../common/Util';
 
 const debug = initDebug('music-metadata:parser:MP4');
 const tagFormat = 'iTunes';

--- a/test/test-file-mp4.ts
+++ b/test/test-file-mp4.ts
@@ -94,13 +94,13 @@ describe("Parse MPEG-4 files with iTunes metadata", () => {
         const filePath = path.join(mp4Samples, "issue-74.m4a");
 
         return parser.initParser(filePath, 'audio/mp4', {native: true}).then(metadata => {
-          const native = metadata.native.iTunes;
-          t.ok(native, 'Native m4a tags should be present');
+          const {native, common} = metadata;
+          t.isDefined(native.iTunes, 'Native m4a tags should be present');
 
           assert.isAtLeast(metadata.native.iTunes.length, 1);
-          t.deepEqual(metadata.common.album, "Live at Tom's Bullpen in Dover, DE (2016-04-30)");
-          t.deepEqual(metadata.common.albumartist, "They Say We're Sinking");
-          t.deepEqual(metadata.common.comment, ["youtube rip\r\nSource: https://www.youtube.com/playlist?list=PLZ4QPxwBgg9TfsFVAArOBfuve_0e7zQaV"]);
+          t.deepEqual(common.album, "Live at Tom's Bullpen in Dover, DE (2016-04-30)");
+          t.deepEqual(common.albumartist, "They Say We're Sinking");
+          t.deepEqual(common.comment, ["youtube rip\r\nSource: https://www.youtube.com/playlist?list=PLZ4QPxwBgg9TfsFVAArOBfuve_0e7zQaV"]);
         });
       });
     });


### PR DESCRIPTION
Fixing issue:
- #222: Bit-rate not always set for m4a file
-  Borewit/music-metadata-browser#24: Can't get bit rate of .m4a type of file