### PR TITLE
Parse POPM fields as ISO-8859-1 (ignore text encoding setting)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "music-metadata",
   "description": "Streaming music metadata parser for node and the browser.",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "author": {
     "name": "Borewit",
     "url": "https://github.com/Borewit"

--- a/src/id3v2/FrameParser.ts
+++ b/src/id3v2/FrameParser.ts
@@ -175,9 +175,9 @@ export default class FrameParser {
         break;
 
       case 'POPM': // Popularimeter
-        fzero = common.findZero(b, offset, length, encoding);
-        const email = common.decodeString(b.slice(offset, fzero), encoding);
-        offset = fzero + FrameParser.getNullTerminatorLength(encoding);
+        fzero = common.findZero(b, offset, length, 'iso-8859-1');
+        const email = common.decodeString(b.slice(offset, fzero), 'iso-8859-1');
+        offset = fzero + FrameParser.getNullTerminatorLength('iso-8859-1');
         const dataLen = length - offset;
         output = {
           email,


### PR DESCRIPTION
Not sure how the POPM e-mail address should be decoded. Using ISO-8859-1 or the ID3v2 text encoding. The spec does not explicitly mention ISO-8859-1, but is does the trick for issue #229.