### PR TITLE
Workaround for ferros/buffer v4, readUInt32LE

### DIFF
--- a/src/id3v2/ID3v24TagMapper.ts
+++ b/src/id3v2/ID3v24TagMapper.ts
@@ -169,7 +169,7 @@ export class ID3v24TagMapper extends CommonTagMapper {
           case 'AverageLevel':
           case 'PeakValue':
             tag.id += ':' + tag.value.owner_identifier;
-            tag.value = tag.value.data.length === 4 ? tag.value.data.readUInt32LE() : null;
+            tag.value = tag.value.data.length === 4 ? tag.value.data.readUInt32LE(0) : null;
             // ToDo: flag warning if: tag.value === null
             break;
           default:


### PR DESCRIPTION
Workaround to address Borewit/music-metadata-browser#28

Fix for a incompatibility issue with [buffer](https://github.com/feross/buffer) v4 is `buffer.readUInt32LE()` is called without any argument, which does not seem to translate to `buffer.readUInt32LE(offset = 0)` in buffer v4.