### PR TITLE
Make ID3v2.3 & IDv2.4 tag mapping case insensitive

### DIFF
--- a/lib/apev2/APEv2TagMapper.ts
+++ b/lib/apev2/APEv2TagMapper.ts
@@ -1,5 +1,5 @@
-import {INativeTagMap} from "../common/GenericTagTypes";
-import {CommonTagMapper} from "../common/GenericTagMapper";
+import {INativeTagMap} from '../common/GenericTagTypes';
+import { CaseInsensitiveTagMap } from '../common/CaseInsensitiveTagMap';
 
 /**
  * ID3v2.2 tag mappings
@@ -74,25 +74,10 @@ const apev2TagMap: INativeTagMap = {
   Weblink: 'website'
 };
 
-export class APEv2TagMapper extends CommonTagMapper {
+export class APEv2TagMapper extends CaseInsensitiveTagMap {
 
   public constructor() {
-
-    const upperCaseMap: INativeTagMap = {};
-
-    for (const tag in apev2TagMap) {
-      upperCaseMap[tag.toUpperCase()] = apev2TagMap[tag];
-    }
-
-    super(['APEv2'], upperCaseMap);
-  }
-
-  /**
-   * @tag  Native header tag
-   * @return common tag name (alias)
-   */
-  protected getCommonName(tag: string) {
-    return this.tagMap[tag.toUpperCase()];
+    super(['APEv2'], apev2TagMap);
   }
 
 }

--- a/lib/common/CaseInsensitiveTagMap.ts
+++ b/lib/common/CaseInsensitiveTagMap.ts
@@ -1,0 +1,24 @@
+import { INativeTagMap, TagType } from './GenericTagTypes';
+import {CommonTagMapper} from './GenericTagMapper';
+
+export class CaseInsensitiveTagMap extends CommonTagMapper {
+
+  public constructor(tagTypes: TagType[], tagMap: INativeTagMap) {
+
+    const upperCaseMap: INativeTagMap = {};
+    for (const tag of Object.keys(tagMap)) {
+      upperCaseMap[tag.toUpperCase()] = tagMap[tag];
+    }
+
+    super(tagTypes, upperCaseMap);
+  }
+
+  /**
+   * @tag  Native header tag
+   * @return common tag name (alias)
+   */
+  protected getCommonName(tag: string) {
+    return this.tagMap[tag.toUpperCase()];
+  }
+
+}

--- a/lib/id3v2/ID3v24TagMapper.ts
+++ b/lib/id3v2/ID3v24TagMapper.ts
@@ -3,6 +3,7 @@ import {CommonTagMapper} from '../common/GenericTagMapper';
 import common from '../common/Util';
 import {IRating, ITag} from '../type';
 import { INativeMetadataCollector } from '../common/MetadataCollector';
+import { CaseInsensitiveTagMap } from '../common/CaseInsensitiveTagMap';
 
 /**
  * ID3v2.3/ID3v2.4 tag mappings
@@ -133,7 +134,7 @@ const id3v24TagMap: INativeTagMap = {
   "TXXX:replaygain_track_gain": "replaygain_track_gain"
 };
 
-export class ID3v24TagMapper extends CommonTagMapper {
+export class ID3v24TagMapper extends CaseInsensitiveTagMap {
 
   public static toRating(popm: any): IRating {
 


### PR DESCRIPTION
Make ID3v2.3 & IDv2.4 tag mapping case insensitive by moving the case-insensitive mapping using as used in APEv2 to re-usable class, which will be used by inherit ID3v2.3/ID3v2.3 mapper from.