### PR TITLE
Prevent MP4-parser to throw error if a file is not entirely build up …

### DIFF
--- a/test/test-file-mp4.ts
+++ b/test/test-file-mp4.ts
@@ -262,4 +262,28 @@ describe("Parse MPEG-4 files with iTunes metadata", () => {
     });
   });
 
+  /**
+   * Related issue: https://github.com/Borewit/music-metadata/issues/318
+   */
+  it('Handle be able to ignore garbage behind mdat root atom', async () => {
+
+    /**
+     * Sample file with 1024 zeroes appended
+     */
+    const m4aFile = path.join(mp4Samples, 'issue-318.m4a');
+
+    const metadata = await mm.parseFile(m4aFile);
+    const {format, common} = metadata;
+    assert.strictEqual(format.container, 'isom/mp42/M4A', 'format.container');
+    assert.strictEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
+    assert.deepEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
+    assert.deepEqual(format.sampleRate, 44100, 'format.sampleRate');
+    assert.deepEqual(format.bitsPerSample, 16, 'format.bitsPerSample');
+    assert.deepEqual(format.tagTypes, ['iTunes'], 'format.tagTypes');
+
+    assert.strictEqual(common.artist, 'Tool', 'common.artist');
+    assert.strictEqual(common.title, 'Fear Inoculum', 'common.title');
+
+  });
+
 });


### PR DESCRIPTION
This PR is to prevent a critical error to be thrown if an MP4 file contains garbage after the root `mdat` atom.

Fix issue #318 
Related: tvararu/music.vararu.org#68

The MP4 parser just logs the issue:
```
  music-metadata:parser:MP4 Ignore atom data: path=mdat, payload-len=20400070 +1ms
  music-metadata:parser:MP4 Error at offset=20517571: FourCC contains invalid characters: 48 b5 9b 70 +0ms
  music-metadata:parser:MP4 Warning: Error at offset=20517571: FourCC contains invalid characters: 48 b5 9b 70 +1ms
```