### PR TITLE
Determine file-type on provided filename path

### DIFF
--- a/lib/ParserFactory.ts
+++ b/lib/ParserFactory.ts
@@ -82,16 +82,21 @@ export class ParserFactory {
 
       const buf = Buffer.alloc(4100);
       await tokenizer.peekBuffer(buf, 0, buf.byteLength, tokenizer.position, true);
-      const guessedType = fileType(buf);
-      if (!guessedType)
-        throw new Error('Failed to determine audio format');
-      debug(`Guessed file type is mime=${guessedType.mime}, extension=${guessedType.ext}`);
-      parserId = ParserFactory.getParserIdForMimeType(guessedType.mime);
-      if (!parserId)
-        throw new Error('Guessed MIME-type not supported: ' + guessedType.mime);
-      return this._parse(tokenizer, parserId, opts);
+      if (opts.path) {
+        parserId = this.getParserIdForExtension(opts.path);
+      }
+      if (!parserId) {
+        const guessedType = fileType(buf);
+        if (!guessedType) {
+          throw new Error('Failed to determine audio format');
+        }
+        debug(`Guessed file type is mime=${guessedType.mime}, extension=${guessedType.ext}`);
+        parserId = ParserFactory.getParserIdForMimeType(guessedType.mime);
+        if (!parserId) {
+          throw new Error('Guessed MIME-type not supported: ' + guessedType.mime);
+        }
+      }
     }
-
     // Parser found, execute parser
     return this._parse(tokenizer, parserId, opts);
   }

--- a/lib/ParserFactory.ts
+++ b/lib/ParserFactory.ts
@@ -82,8 +82,8 @@ export class ParserFactory {
 
       const buf = Buffer.alloc(4100);
       await tokenizer.peekBuffer(buf, 0, buf.byteLength, tokenizer.position, true);
-      if (opts.path) {
-        parserId = this.getParserIdForExtension(opts.path);
+      if (tokenizer.fileInfo.path) {
+        parserId = this.getParserIdForExtension(tokenizer.fileInfo.path);
       }
       if (!parserId) {
         const guessedType = fileType(buf);

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -457,7 +457,6 @@ export interface IAudioMetadata extends INativeAudioMetadata {
 export type ParserType = 'mpeg' | 'apev2' | 'mp4' | 'asf' | 'flac' | 'ogg' | 'aiff' | 'wavpack' | 'riff' | 'musepack' | 'dsf' | 'dsdiff' | 'adts' | 'matroska';
 
 export interface IOptions {
-  path?: string,
 
   /**
    * default: `false`, if set to `true`, it will parse the whole media file if required to determine the duration.


### PR DESCRIPTION
Sometimes uploading a audio file with a browser (using [music-metadata-browser](https://github.com/Borewit/music-metadata-browser)), the browser does not provide a MIME-type.
In addition to that, the automatic build in file type detection provides by [file-type](https://github.com/sindresorhus/file-type) may fail as well.

Therefor I also enable the file-type determination, based on file name, which is passed by the parseBlob, in case the [Bob](https://javascript.info/blob) is a [File](https://javascript.info/file).

Enabling: [music-metadata-browser#116](https://github.com/Borewit/music-metadata-browser/pull/116)

* [x] Implement feature
* [x] Need to check for side effects of setting `options.path` with an unresolvable  file path.