### PR TITLE
Enhance MPEG (MP3) codec description

### DIFF
--- a/lib/mpeg/MpegParser.ts
+++ b/lib/mpeg/MpegParser.ts
@@ -209,7 +209,7 @@ class MpegFrameHeader {
     this.version = MpegFrameHeader.VersionID[this.versionIndex];
     this.channelMode = MpegFrameHeader.ChannelMode[this.channelModeIndex];
 
-    this.codec = 'MP' + this.layer;
+    this.codec = `MPEG ${this.version} Layer ${this.layer}`;
 
     // Calculate bitrate
     const bitrateInKbps = this.calcBitrate();

--- a/test/test-file-ape.ts
+++ b/test/test-file-ape.ts
@@ -64,7 +64,7 @@ describe('Parse APEv2 header', () => {
     });
     const {format, common, quality} = metadata;
     assert.strictEqual(format.container, 'MPEG', 'format.container');
-    assert.strictEqual(format.codec, 'MP3', 'format.codec');
+    assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
     assert.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
     assert.strictEqual(format.tool, 'LAME3.99r', 'format.codecProfile');
     assert.approximately(format.duration, 348.421, 1 / 500, 'format.duration');

--- a/test/test-file-mp3.ts
+++ b/test/test-file-mp3.ts
@@ -34,7 +34,7 @@ describe('Parse MP3 files', () => {
       const {format, common} = metadata;
 
       assert.deepEqual(format.container, 'MPEG', 'format.container');
-      assert.deepEqual(format.codec, 'MP3', 'format.codec');
+      assert.deepEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
       assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
 
@@ -59,7 +59,7 @@ describe('Parse MP3 files', () => {
       assert.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.tagTypes');
       assert.approximately(format.duration, 61.73, 1 / 100, 'format.duration');
       assert.strictEqual(format.container, 'MPEG', 'format.container');
-      assert.strictEqual(format.codec, 'MP3', 'format.codec');
+      assert.strictEqual(format.codec, 'MPEG 2 Layer 3', 'format.codec');
       assert.strictEqual(format.lossless, false, 'format.lossless');
       assert.strictEqual(format.sampleRate, 22050, 'format.sampleRate = 44.1 kHz');
       assert.strictEqual(format.bitrate, 64000, 'format.bitrate = 128 kbit/sec');

--- a/test/test-file-mpeg.ts
+++ b/test/test-file-mpeg.ts
@@ -38,7 +38,7 @@ describe('Parse MPEG', () => {
 
     t.deepEqual(metadata.format.tagTypes, ['ID3v2.3', 'ID3v1'], 'Tags: ID3v1 & ID3v2.3');
     t.strictEqual(metadata.format.container, 'MPEG', 'format.container = MPEG');
-    t.strictEqual(metadata.format.codec, 'MP2', 'format.codec = mp2 (MPEG-2 Audio Layer II)');
+    t.strictEqual(metadata.format.codec, 'MPEG 1 Layer 2', 'format.codec = MPEG-1 Audio Layer II');
     t.strictEqual(metadata.format.bitrate, 128000, 'format.bitrate = 128 kbit/sec');
     t.strictEqual(metadata.format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
     t.strictEqual(metadata.format.numberOfSamples, 23040, 'format.numberOfSamples = 23040');
@@ -249,7 +249,7 @@ describe('Parse MPEG', () => {
       t.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v2.4', 'ID3v1'], 'format.tagTypes');
       t.strictEqual(format.duration, expectedDuration, 'format.duration');
       t.deepEqual(format.container, 'MPEG', 'format.container');
-      t.deepEqual(format.codec, 'MP3', 'format.codec');
+      t.deepEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
       t.strictEqual(format.lossless, false, 'format.lossless');
       t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       t.strictEqual(format.bitrate, 320000, 'format.bitrate = 160 kbit/sec');
@@ -368,7 +368,7 @@ describe('Parse MPEG', () => {
     const filePath = path.join(issueDir, 'mp3', 'issue-347.mp3');
     const {format} = await mm.parseFile(filePath);
     assert.strictEqual(format.container, 'MPEG', 'format.container');
-    assert.strictEqual(format.codec, 'MP3', 'format.codec');
+    assert.strictEqual(format.codec, 'MPEG 2.5 Layer 3', 'format.codec');
     assert.strictEqual(format.codecProfile, 'CBR', 'format.codec');
     assert.deepEqual(format.numberOfChannels, 1, 'format.numberOfChannels');
     assert.deepEqual(format.sampleRate, 8000, 'format.sampleRate');

--- a/test/test-id3v1.1.ts
+++ b/test/test-id3v1.1.ts
@@ -13,7 +13,7 @@ describe('Parsing MPEG / ID3v1', () => {
     function checkFormat(format: mm.IFormat) {
       assert.deepEqual(format.tagTypes, ['ID3v1'], 'format.tagTypes');
       assert.strictEqual(format.container, 'MPEG', 'format.container');
-      assert.strictEqual(format.codec, 'MP3', 'format.codec');
+      assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
       assert.strictEqual(format.lossless, false, 'format.lossless');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       assert.strictEqual(format.bitrate, 160000, 'format.bitrate = 160 kbit/sec');
@@ -66,7 +66,7 @@ describe('Parsing MPEG / ID3v1', () => {
       assert.deepEqual(format.tagTypes, [], 'format.tagTypes');
       assert.strictEqual(format.duration, 2.088, 'format.duration');
       assert.strictEqual(format.container, 'MPEG', 'format.container');
-      assert.strictEqual(format.codec, 'MP3', 'format.codec');
+      assert.strictEqual(format.codec, 'MPEG 2 Layer 3', 'format.codec');
       assert.strictEqual(format.lossless, false, 'format.lossless');
       assert.strictEqual(format.sampleRate, 16000, 'format.sampleRate = 44.1 kHz');
       assert.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 kbit/sec');
@@ -92,7 +92,7 @@ describe('Parsing MPEG / ID3v1', () => {
       assert.strictEqual(format.duration, 33.38448979591837, 'format.duration (checked with foobar)');
       assert.deepEqual(format.tagTypes, ['ID3v1'], 'format.tagTypes');
       assert.deepEqual(format.container, 'MPEG', 'format.container');
-      assert.deepEqual(format.codec, 'MP3', 'format.codec');
+      assert.deepEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
       assert.strictEqual(format.lossless, false, 'format.lossless');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       // t.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 bit/sec');

--- a/test/test-id3v2-duration-allframes.ts
+++ b/test/test-id3v2-duration-allframes.ts
@@ -31,7 +31,7 @@ it("should decode id3v2-duration-allframes", () => {
     t.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
     t.strictEqual(format.duration, 57 * 1152 / format.sampleRate, 'format.duration (test duration=true)');
     t.strictEqual(format.container, 'MPEG', 'format.container');
-    t.strictEqual(format.codec, 'MP3', 'format.codec');
+    t.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
     t.strictEqual(format.tool, 'LAME 3.98.4', 'format.tool');
   }
 

--- a/test/test-id3v2.3.ts
+++ b/test/test-id3v2.3.ts
@@ -37,7 +37,7 @@ describe('Extract metadata from ID3v2.3 header', () => {
       assert.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 kbit/sec');
       assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels 2 (stereo)');
       assert.strictEqual(format.container, 'MPEG', 'format.container');
-      assert.strictEqual(format.codec, 'MP3', 'format.codec');
+      assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
       assert.strictEqual(format.tool, 'LAME3.98r', 'format.tool');
       assert.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
     }
@@ -108,7 +108,7 @@ describe('Extract metadata from ID3v2.3 header', () => {
         assert.strictEqual(format.duration, 247.84979591836733, 'format.duration');
         assert.deepEqual(format.tagTypes, ['ID3v2.3'], 'format.tagTypes');
         assert.strictEqual(format.container, 'MPEG', 'format.container');
-        assert.strictEqual(format.codec, 'MP3', 'format.codec');
+        assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
         assert.strictEqual(format.lossless, false, 'format.lossless');
         assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
         assert.strictEqual(format.bitrate, 128000, 'format.bitrate = 128 bit/sec');

--- a/test/test-id3v2.4.ts
+++ b/test/test-id3v2.4.ts
@@ -21,7 +21,7 @@ describe("Decode MP3/ID3v2.4", () => {
       t.strictEqual(metadata.format.bitrate, 128000, 'format.bitrate = 128 kbit/sec');
       t.strictEqual(metadata.format.codecProfile, 'CBR', 'format.codecProfile = CBR');
       t.strictEqual(metadata.format.container, 'MPEG', 'format.container');
-      t.strictEqual(metadata.format.codec, 'MP3', 'format.codec');
+      t.strictEqual(metadata.format.codec, 'MPEG 1 Layer 3', 'format.codec');
       t.strictEqual(metadata.format.tool, 'LAME3.98r', 'format.tool');
       t.strictEqual(metadata.format.numberOfChannels, 2, 'format.numberOfChannels = 2');
 

--- a/test/test-mime.ts
+++ b/test/test-mime.ts
@@ -94,7 +94,7 @@ describe("MIME & extension mapping", () => {
 
       const metadata = await mm.parseFile(path.join(samplePath, 'mp3', '1a643e9e0743dee8732554d0e870055a'));
       assert.equal(metadata.format.container, 'MPEG');
-      assert.equal(metadata.format.codec, 'MP3');
+      assert.equal(metadata.format.codec, 'MPEG 1 Layer 3');
     });
 
     it("should throw error on unrecognized MIME-type", () => {

--- a/test/test-picard-parsing.ts
+++ b/test/test-picard-parsing.ts
@@ -378,7 +378,7 @@ describe('Parsing of metadata saved by \'Picard\' in audio files', () => {
       function checkFormat(format) {
         t.deepEqual(format.tagTypes, ['ID3v2.3'], 'format.tagTypes');
         t.deepEqual(format.container, 'MPEG', 'format.container');
-        t.deepEqual(format.codec, 'MP3', 'format.codec');
+        t.deepEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
         t.strictEqual(format.duration, 2.1681632653061222, 'format.duration');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
         t.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
@@ -500,7 +500,7 @@ describe('Parsing of metadata saved by \'Picard\' in audio files', () => {
       function checkFormat(format: IFormat) {
         t.deepEqual(format.tagTypes, ['ID3v2.4'], 'format.tagTypes');
         t.strictEqual(format.container, 'MPEG', 'format.container');
-        t.strictEqual(format.codec, 'MP3', 'format.codec');
+        t.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
         t.strictEqual(format.codecProfile, 'V2', 'format.codecProfile = V2');
         t.strictEqual(format.tool, 'LAME3.99r', 'format.tool');
         t.strictEqual(format.duration, 2.1681632653061222, 'format.duration');


### PR DESCRIPTION
Implements: #349

Include MPEG version in metadata.common.codec:

| Old value | new value |
| -----| ----| 
| MP1 | MPEG 2.5 Layer 1 | 
| MP2 | MPEG 1 Layer 2 | 
| MP3 | MPEG 2 Layer 3 | 
