### PR TITLE
Fix parsing MPEG-4 stream with unknown file size

### DIFF
--- a/lib/mp4/MP4Parser.ts
+++ b/lib/mp4/MP4Parser.ts
@@ -147,7 +147,7 @@ export class MP4Parser extends BasicParser {
     let remainingFileSize = this.tokenizer.fileSize;
     const rootAtoms: Atom[] = [];
 
-    while (remainingFileSize > 0) {
+    while (!this.tokenizer.fileSize || remainingFileSize > 0) {
       try {
         await this.tokenizer.peekToken<AtomToken.IAtomHeader>(AtomToken.Header);
       } catch (error) {


### PR DESCRIPTION
Fix:
* #354: _Parse MPEG-4 stream with unknown file-size_