### PR TITLE
Add Travis-CI Node v13 target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
  - "10"
  - "11"
  - "12"
+ - "13"
 install:
 - yarn install
 script:


### PR DESCRIPTION
Add [Node.js v13](https://nodejs.org/fr/blog/release/v13.0.0/) target to [TravisCI](https://travis-ci.org/Borewit/music-metadata).