### PR TITLE
fix mp4 audiotracks without description

### DIFF
--- a/lib/mp4/MP4Parser.ts
+++ b/lib/mp4/MP4Parser.ts
@@ -179,7 +179,7 @@ export class MP4Parser extends BasicParser {
     }
 
     const audioTracks = this.tracks.filter(track => {
-      return track.soundSampleDescription.length >= 1 && track.soundSampleDescription[0].description.sampleRate > 0;
+      return track.soundSampleDescription.length >= 1 && track.soundSampleDescription[0].description && track.soundSampleDescription[0].description.sampleRate > 0;
     });
 
     if (audioTracks.length >= 1) {


### PR DESCRIPTION
Fix `UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'sampleRate' of undefined`.

Some mp4 files seems to have audiotracks without description.

I think the `undefined` comes from https://github.com/Borewit/music-metadata/blob/3bf63a76be7bc44d98aec1b59cc5564c5f9ac560/lib/mp4/MP4Parser.ts#L505, because of an unknown version, the 'description' property is not set.