### PR TITLE
atom w/0 length extends to end of file

### DIFF
--- a/lib/mp4/Atom.ts
+++ b/lib/mp4/Atom.ts
@@ -19,6 +19,10 @@ export class Atom {
     if (extended) {
       header.length = await tokenizer.readToken<number>(AtomToken.ExtendedSize);
     }
+    const extendToEOF = ((header.length === 0) && (header.name === 'mdat') && !parent);
+    if (extendToEOF) {
+        header.length = tokenizer.fileInfo.size - tokenizer.position + 8;
+    }
     const atomBean = new Atom(header, extended, parent);
     debug(`parse atom name=${atomBean.atomPath}, extended=${atomBean.extended}, offset=${offset}, len=${atomBean.header.length}`); //  buf.toString('ascii')
     await atomBean.readData(tokenizer, dataHandler);


### PR DESCRIPTION
mp4 parsing was hanging while processing some files we encoded with ffmpeg/libfdk_aac. We found there was an 'mdat' atom in the file being parsed that indicated its length was '0'. This caused '.getPayloadLength()' to return -8. So, when the code tried to skip past the payload during parsing, it would actually move the tokenizer **back** 8 positions with tokenizer.ignore(), leading to an endless loop.

I don't have a copy of the mpeg file format spec, but I found this:

https://wikileaks.org/sony/docs/05/docs/Apple/qtff.pdf

and on page 23 it points out that a size of 0 on a top level atom indicates the payload is the rest of the file. I can't tell if this applies to all atoms or only 'mdat', so the patch here only works with 'mdat'.
