### PR TITLE
fixes case with overloaded COMM tag in ID3v2.4

### DIFF
--- a/lib/id3v2/ID3v2Parser.ts
+++ b/lib/id3v2/ID3v2Parser.ts
@@ -198,6 +198,10 @@ export class ID3v2Parser {
         for (const value of tag.value) {
           this.addTag(ID3v2Parser.makeDescriptionTagName(tag.id, value.description), value.text);
         }
+      } else if (tag.id === 'COMM') {
+        for (const value of tag.value) {
+          this.addTag(ID3v2Parser.makeDescriptionTagName(tag.id, value.description), value);
+        }
       } else if (Array.isArray(tag.value)) {
         for (const value of tag.value) {
           this.addTag(tag.id, value);


### PR DESCRIPTION
Fixes #502 

Adds a call to `makeDescriptionTagName` for `tag.id === "COMM"` to split overloaded COMM tags into, eg, COMM.iTunPGAP, COMM.iTunSMPB and COMM.iTunNORM in addition to COMM.

All tests are still passing. I'm not super familiar with how your test cases are architected or I'd submit a new one to cover the case I'm trying to fix, but there's a sample file in #502. 