### PR TITLE
File can be parsed without asserting frame-data-left

### DIFF
--- a/lib/mpeg/MpegParser.ts
+++ b/lib/mpeg/MpegParser.ts
@@ -610,7 +610,7 @@ export class MpegParser extends AbstractID3Parser {
   }
 
   private async skipFrameData(frameDataLeft: number): Promise<void> {
-    assert.ok(frameDataLeft >= 0, 'frame-data-left cannot be negative');
+    // assert.ok(frameDataLeft >= 0, 'frame-data-left cannot be negative');
     await this.tokenizer.ignore(frameDataLeft);
     this.countSkipFrameData += frameDataLeft;
   }


### PR DESCRIPTION
This isn't really a PR I expect to be merged. I just noticed that I couldn't parse this file's metadata because of this assertion and removing it doesn't appear to cause side-effects and the file's metadata is successfully parsed.

Here's the file: https://www.dropbox.com/s/flj528qq9a6n1gg/Little%20Bears%20Visit.mp3?dl=0

Without this change, I get the following error:

```
AssertionError [ERR_ASSERTION]: frame-data-left cannot be negative -5
    at MpegParser.skipFrameData (/Users/kentcdodds/code/podcastify-dir/node_modules/music-metadata/lib/mpeg/MpegParser.js:499:16)
    at MpegParser.readXtraInfoHeader (/Users/kentcdodds/code/podcastify-dir/node_modules/music-metadata/lib/mpeg/MpegParser.js:465:28)
    at async MpegParser.skipSideInformation (/Users/kentcdodds/code/podcastify-dir/node_modules/music-metadata/lib/mpeg/MpegParser.js:441:9)
    at async MpegParser.parseAudioFrameHeader (/Users/kentcdodds/code/podcastify-dir/node_modules/music-metadata/lib/mpeg/MpegParser.js:400:13)
    at async MpegParser._parse (/Users/kentcdodds/code/podcastify-dir/node_modules/music-metadata/lib/mpeg/MpegParser.js:233:24)
    at async MpegParser.parseID3v2 (/Users/kentcdodds/code/podcastify-dir/node_modules/music-metadata/lib/id3v2/AbstractID3Parser.js:40:9)
    at async MpegParser.parse (/Users/kentcdodds/code/podcastify-dir/node_modules/music-metadata/lib/id3v2/AbstractID3Parser.js:23:13)
    at async Function._parse (/Users/kentcdodds/code/podcastify-dir/node_modules/music-metadata/lib/ParserFactory.js:158:9)
    at async Object.parseFile (/Users/kentcdodds/code/podcastify-dir/node_modules/music-metadata/lib/index.js:44:16)
```

I added a few logs and here's some variable values I get:

```
> { headerTag: 'Xing' } (not sure where the ">" is coming from on this log...)
{ headerTag: 'LAME' }
{ encoderVersion: StringType { len: 6, encoding: 'ascii' } }
{ frameDataLeft: -5 }
```

If I _do_ comment out the assertion, here's the value of the metadata I get back:

```js
{
  format: {
    tagTypes: [ 'ID3v2.3' ],
    trackInfo: [],
    lossless: false,
    container: 'MPEG',
    codec: 'MPEG 2 Layer 3',
    sampleRate: 22050,
    numberOfChannels: 2,
    bitrate: 70860.66118935838,
    tool: 'LAME U\x7Fs\x10d\x05',
    duration: 817.92,
    codecProfile: 'V10'
  },
  native: {
    'ID3v2.3': [
      { id: 'TXXX:book_genre', value: 'Kids:Ages 0-4' },
      { id: 'TXXX:narrated_by', value: 'Owen Jordan' },
      { id: 'TXXX:asin', value: 'B002VA3NYM' },
      { id: 'TSSE', value: 'Lavf58.3.100' },
      { id: 'TXXX:year', value: '2008-04-04' },
      { id: 'TXXX:product_id', value: 'BK_WEST_000077' },
      { id: 'TPE1', value: 'Else Holmelumd Minarik' },
      { id: 'TPE2', value: 'Else Holmelumd Minarik' },
      { id: 'TALB', value: "Little Bear's Visit" },
      { id: 'TCON', value: 'Audiobook' },
      {
        id: 'TCOP',
        value: '©1961 Else Holmelmund Minarik (P)1967 Weston Woods'
      },
      { id: 'TYER', value: '2008' },
      { id: 'TIT2', value: "Little Bear's Visit" },
      { id: 'TXXX:author', value: 'Else Holmelumd Minarik' },
      {
        id: 'TXXX:json64',
        value: 'eyJzdW1tYXJ5IjoiTGl0dGxlIEJlYXIgZ29lcyB0byB2aXNpdCBHcmFuZG1vdGhlciBhbmQgR3JhbmRmYXRoZXIgQmVhciBhbmQgc3BlbmRzIHRoZSBkYXkgd2l0aCB0aGVtLiIsInJhdGluZ19hdmVyYWdlIjoiNC41MzI0Njc1MzI0Njc1MzMiLCJjb3B5cmlnaHQiOiLCqTE5NjEgRWxzZSBIb2xtZWxtdW5kIE1pbmFyaWsgKFApMTk2NyBXZXN0b24gV29vZHMiLCJhdXRob3IiOiJFbHNlIEhvbG1lbHVtZCBNaW5hcmlrIiwidGl0bGUiOiJMaXR0bGUgQmVhcidzIFZpc2l0IiwidGl0bGVfc2hvcnQiOiJMaXR0bGUgQmVhcidzIFZpc2l0IiwiaW5mb19saW5rIjoiaHR0cHM6Ly93d3cuYXVkaWJsZS5jb20vcGQvTGl0dGxlLUJlYXJzLVZpc2l0LUF1ZGlvYm9vay9CMDAyVkEzTllNIiwicmF0aW5nX2NvdW50IjoiNzciLCJkdXJhdGlvbiI6IjAwOjE0OjM3IiwiYXV0aG9yX2xpbmsiOiJodHRwczovL3d3dy5hdWRpYmxlLmNvbS9hdXRob3IvRWxzZS1Ib2xtZWx1bWQtTWluYXJpay9CMDAwQVFUU1RJIiwiZmlsZW5hbWUiOiJMaXR0bGUgQmVhcnMgVmlzaXQiLCJuYXJyYXRlZF9ieSI6Ik93ZW4gSm9yZGFuIiwicmVsZWFzZV9kYXRlIjoiMDQtQVBSLTIwMDgiLCJwcm9kdWN0X2lkIjoiQktfV0VTVF8wMDAwNzciLCJnZW5yZSI6IktpZHM6QWdlcyAwLTQiLCJwdWJsaXNoZXIiOiJXZXN0b24gV29vZHMgU3R1ZGlvcyIsImFzaW4iOiJCMDAyVkEzTllNIiwicHVyY2hhc2VfZGF0ZSI6IjEyLTI4LTE3In0='
      },
      {
        id: 'TXXX:creation_time',
        value: '2020-02-01T21:34:45.000000Z'
      },
      {
        id: 'APIC',
        value: {
          format: 'image/png',
          type: 'Cover (front)',
          description: 'Album cover',
          data: Buffer(439644) [Uint8Array] [
            137,  80,  78,  71,  13,  10,  26,  10,   0,  0,   0,  13,
             73,  72,  68,  82,   0,   0,   1, 244,   0,  0,   1, 244,
              8,   2,   0,   0,   0,  68, 180,  72, 221,  0,   0,   0,
              9, 112,  72,  89, 115,   0,   0,   0,   1,  0,   0,   0,
              1,   0,  79,  37, 196, 214,   0,   0,  16,  0,  73,  68,
             65,  84, 120, 156, 236, 125,   7,  84,  99, 71, 150, 118,
              1,  77, 206,  57, 103,  16,  89, 100,  16, 65,  17,  36,
            161,   0,  18, 146,   0,   1,  18,  18,  40, 33, 144, 136,
              2,  68, 206, 153,
            ... 439544 more items
          ]
        }
      }
    ]
  },
  quality: { warnings: [] },
  common: {
    track: { no: null, of: null },
    disk: { no: null, of: null },
    asin: 'B002VA3NYM',
    encodersettings: 'Lavf58.3.100',
    artists: [ 'Else Holmelumd Minarik' ],
    artist: 'Else Holmelumd Minarik',
    albumartist: 'Else Holmelumd Minarik',
    album: "Little Bear's Visit",
    genre: [ 'Audiobook' ],
    copyright: '©1961 Else Holmelmund Minarik (P)1967 Weston Woods',
    year: 2008,
    title: "Little Bear's Visit",
    picture: [
      {
        format: 'image/png',
        type: 'Cover (front)',
        description: 'Album cover',
        data: Buffer(439644) [Uint8Array] [
          137,  80,  78,  71,  13,  10,  26,  10,   0,  0,   0,  13,
           73,  72,  68,  82,   0,   0,   1, 244,   0,  0,   1, 244,
            8,   2,   0,   0,   0,  68, 180,  72, 221,  0,   0,   0,
            9, 112,  72,  89, 115,   0,   0,   0,   1,  0,   0,   0,
            1,   0,  79,  37, 196, 214,   0,   0,  16,  0,  73,  68,
           65,  84, 120, 156, 236, 125,   7,  84,  99, 71, 150, 118,
            1,  77, 206,  57, 103,  16,  89, 100,  16, 65,  17,  36,
          161,   0,  18, 146,   0,   1,  18,  18,  40, 33, 144, 136,
            2,  68, 206, 153,
          ... 439544 more items
        ]
      }
    ]
  }
}
```

I'm definitely outside my wheelhouse here, but hopefully this is enough information to help come up with what's going on.