### PR TITLE
Adjust minimum MPEG frame size to 163 bytes

### DIFF
--- a/lib/mpeg/MpegParser.ts
+++ b/lib/mpeg/MpegParser.ts
@@ -362,7 +362,7 @@ export class MpegParser extends AbstractID3Parser {
     while (true) {
       let bo = 0;
       this.syncPeek.len = await this.tokenizer.peekBuffer(this.syncPeek.buf, {length: maxPeekLen, mayBeLess: true});
-      if (this.syncPeek.len <= 256) {
+      if (this.syncPeek.len <= 163) {
         throw new EndOfStreamError();
       }
       while (true) {


### PR DESCRIPTION
I am not sure what the minimum MPEG frame size is, 

With
```
samples_per_frame = 8
bitrate  = 8000
samplingRate = 48000

calculated frame size = (samples_per_frame/8) * 8000 / D2 48000 = 8 bytes
```
which I am not sure realistic.

I picked 163, as with 162 or lower unit tests start to fail.

