### PR TITLE
Allow Four-CC code with 4 times byte value 0x00

### DIFF
--- a/lib/common/FourCC.ts
+++ b/lib/common/FourCC.ts
@@ -1,7 +1,7 @@
 import Util from './Util';
 import { IToken } from "strtok3/lib/core";
 
-const validFourCC =  /(^[\x21-\x7e©][\x20-\x7e\x00()]{3})|^(\x20[\x21-\x7e]{3})/;
+const validFourCC =  /^[\x21-\x7e©][\x20-\x7e\x00()]{3}/;
 
 /**
  * Token for read FourCC
@@ -11,9 +11,12 @@ export const FourCcToken: IToken<string> = {
   len: 4,
 
   get: (buf: Buffer, off: number): string => {
-    const id = buf.toString("binary", off, off + FourCcToken.len);
-    if (!id.match(validFourCC)) {
-      throw new Error(`FourCC contains invalid characters: ${Util.a2hex(id)}`);
+    const id = buf.toString('binary', off, off + FourCcToken.len);
+    switch (id) {
+      default:
+        if (!id.match(validFourCC)) {
+          throw new Error(`FourCC contains invalid characters: ${Util.a2hex(id)} "${id}"`);
+        }
     }
     return id;
   },

--- a/lib/riff/RiffChunk.ts
+++ b/lib/riff/RiffChunk.ts
@@ -1,5 +1,4 @@
 import * as Token from 'token-types';
-import {FourCcToken} from '../common/FourCC';
 import {IChunkHeader} from '../iff';
 import { IGetToken } from 'strtok3/lib/core';
 export {IChunkHeader} from '../iff';
@@ -13,7 +12,7 @@ export const Header: IGetToken<IChunkHeader> = {
   get: (buf, off): IChunkHeader => {
     return {
       // Group-ID
-      chunkID: FourCcToken.get(buf, off),
+      chunkID: buf.toString('binary', off, 4),
       // Size
       chunkSize: buf.readUInt32LE(off + 4)
     };

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -75,7 +75,7 @@ describe("shared utility functionality", () => {
       {fourCC: '-\x00\x00\x00', valid: true}, // Used in MP4
       {fourCC: '©nam', valid: true}, // Used in MP4
       {fourCC: '(c) ', valid: true}, // Used in AIFF
-      {fourCC: ' XML', valid: true}, // Used in WAVE
+      {fourCC: ' XML', valid: false},
       {fourCC: ' XM ', valid: false}
     ];
 
@@ -91,7 +91,7 @@ describe("shared utility functionality", () => {
         } catch (e) {
           valid = false;
         }
-        t.strictEqual(valid, data.valid, `FourCC: ${util.a2hex(data.fourCC)}`);
+        t.strictEqual(valid, data.valid, `FourCC: ${util.a2hex(data.fourCC)} "${data.fourCC}"`);
         if (data.valid) {
           t.strictEqual(fourCC, data.fourCC);
         }


### PR DESCRIPTION
Stop using the FourCC object and allow the ID to take any value.

Fix #587