### PR TITLE
Fix type definitions grouping and track/disk no/of

### DIFF
--- a/lib/type.ts
+++ b/lib/type.ts
@@ -42,8 +42,8 @@ export interface IRating {
 }
 
 export interface ICommonTagsResult {
-  track: { no: number, of: number };
-  disk: { no: number, of: number };
+  track: { no: number | null, of: number | null };
+  disk: { no: number | null, of: number | null };
   /**
    * Release year
    */

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -162,7 +162,7 @@ export interface ICommonTagsResult {
   mixer?: string[];
   technician?: string[];
   label?: string[];
-  grouping?: string[];
+  grouping?: string;
   subtitle?: string[];
   description?: string[];
   discsubtitle?: string[];


### PR DESCRIPTION
Fix type definitions: 
* `common.grouping` from `string[]` to `string`
* `common.track.no`  from `number` to `number | null`
* `common.track.of`  from `number` to `number | null`
* `common.disk.no`  from `number` to `number | null`
* `common.disk.of`  from `number` to `number | null`

Fix #622.