### PR TITLE
Ignore Node.js engine for development engine

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -15,8 +15,11 @@ jobs:
         with:
           node-version: 12.x
 
-      - name: Install
-        run: yarn install
+      - name: Install production dependencies, check node engine compatiblity
+        run: yarn install --production=true
+
+      - name: Install development dependencies
+        run: yarn install --production=false --ignore-engines
 
       - name: Build & Code analysis
         run: yarn run lint
@@ -54,8 +57,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install
-        run: yarn install
+      - name: Install dependencies
+        run: yarn install --ignore-engines
 
       - name: Download build
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Only require production dependencies to adhere to the Node engine version.
This allows development dependencies to be updated, even if they do not comply with the package engine version.