### PR TITLE
Map audio/aac to ADTS parsers (currently covered by MPEG-parser).

### DIFF
--- a/lib/ParserFactory.ts
+++ b/lib/ParserFactory.ts
@@ -181,13 +181,15 @@ export class ParserFactory {
   public static async loadParser(moduleName: ParserType): Promise<ITokenParser> {
     switch (moduleName) {
       case 'aiff': return new AIFFParser();
+      case 'adts':
+      case 'mpeg':
+        return new MpegParser();
       case 'apev2': return new APEv2Parser();
       case 'asf': return new AsfParser();
       case 'dsf': return new DsfParser();
       case 'dsdiff': return new DsdiffParser();
       case 'flac': return new FlacParser();
       case 'mp4': return new MP4Parser();
-      case 'mpeg': return new MpegParser();
       case 'musepack': return new MusepackParser();
       case 'ogg': return new OggParser();
       case 'riff': return new WaveParser();
@@ -234,7 +236,11 @@ export class ParserFactory {
 
           case 'mp3': // Incorrect MIME-type, Chrome, in Web API File object
           case 'mpeg':
-            return 'mpeg'; // ToDo: handle ID1 header as well
+            return 'mpeg';
+
+          case 'aac':
+          case 'aacp':
+            return 'adts';
 
           case 'flac':
             return 'flac';
@@ -244,8 +250,6 @@ export class ParserFactory {
             return 'apev2';
 
           case 'mp4':
-          case 'aac':
-          case 'aacp':
           case 'm4a':
             return 'mp4';
 

--- a/test/test-file-aac.ts
+++ b/test/test-file-aac.ts
@@ -23,7 +23,7 @@ describe('Parse ADTS/AAC', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async () => {
-        const metadata = await parser.initParser(path.join(samplePath, 'adts-mpeg4.aac'), 'audio/mpeg', {
+        const metadata = await parser.initParser(path.join(samplePath, 'adts-mpeg4.aac'), 'audio/aac', {
           duration: true
         });
         checkFormat(metadata.format, 'ADTS/MPEG-4', 'AAC', 'AAC LC', 16000, 1, 20399, 256000);
@@ -35,7 +35,7 @@ describe('Parse ADTS/AAC', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async () => {
-        const metadata = await parser.initParser(path.join(samplePath, 'adts-mpeg4-2.aac'), 'audio/mpeg', {
+        const metadata = await parser.initParser(path.join(samplePath, 'adts-mpeg4-2.aac'), 'audio/aac', {
           duration: true
         });
         checkFormat(metadata.format, 'ADTS/MPEG-4', 'AAC', 'AAC LC', 44100, 2, 128000, 14336);


### PR DESCRIPTION
Map MIME-type `audio/aac` to Audio Data Transport Stream (ADTS) parser. 

Fix #654.