### PR TITLE
Support ` XML` WAVE Chunk-ID.

### DIFF
--- a/lib/common/FourCC.ts
+++ b/lib/common/FourCC.ts
@@ -1,7 +1,7 @@
 import Util from './Util';
 import { IToken } from "strtok3/lib/core";
 
-const validFourCC =  /^[\x21-\x7e©][\x20-\x7e\x00()3]/;
+const validFourCC =  /(^[\x21-\x7e©][\x20-\x7e\x00()]{3})|^(\x20[\x21-\x7e]{3})/;
 
 /**
  * Token for read FourCC

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -74,7 +74,9 @@ describe("shared utility functionality", () => {
       {fourCC: '----', valid: true}, // Used in MP4
       {fourCC: '-\x00\x00\x00', valid: true}, // Used in MP4
       {fourCC: '©nam', valid: true}, // Used in MP4
-      {fourCC: '(c) ', valid: true} // Used in AIFF
+      {fourCC: '(c) ', valid: true}, // Used in AIFF
+      {fourCC: ' XML', valid: true}, // Used in WAVE
+      {fourCC: ' XM ', valid: false}
     ];
 
     it("should only accept a valid identifier, otherwise is should throw an error", () => {


### PR DESCRIPTION
Fix #708.

Allow a RIFF/WAVE chunk-ID to start with a space, e.g. chunk-ID =  ` XML`