### PR TITLE
Add chapter.start & chapter.timescale

### DIFF
--- a/lib/mp4/MP4Parser.ts
+++ b/lib/mp4/MP4Parser.ts
@@ -545,7 +545,7 @@ export class MP4Parser extends BasicParser {
         .slice(0, i)
         .reduce((acc, cur) => acc + cur.duration, 0);
 
-      const chunkOffset = chapterTrack.chunkOffsetTable[i];  
+      const chunkOffset = chapterTrack.chunkOffsetTable[i];
       const nextChunkLen = chunkOffset - this.tokenizer.position;
       const sampleSize = chapterTrack.sampleSize > 0 ? chapterTrack.sampleSize : chapterTrack.sampleSizeTable[i];
       len -= nextChunkLen + sampleSize;

--- a/lib/mp4/MP4Parser.ts
+++ b/lib/mp4/MP4Parser.ts
@@ -541,7 +541,9 @@ export class MP4Parser extends BasicParser {
     }
     const chapters: IChapter[] = [];
     for (let i = 0; i < chapterTrack.chunkOffsetTable.length && len > 0; ++i) {
-      const chunkOffset = chapterTrack.chunkOffsetTable[i];
+      const start = chapterTrack.timeToSampleTable.slice(0, i ).reduce((acc, cur)=> acc + cur.duration, 0);
+
+      const chunkOffset = chapterTrack.chunkOffsetTable[i];  
       const nextChunkLen = chunkOffset - this.tokenizer.position;
       const sampleSize = chapterTrack.sampleSize > 0 ? chapterTrack.sampleSize : chapterTrack.sampleSizeTable[i];
       len -= nextChunkLen + sampleSize;
@@ -551,6 +553,8 @@ export class MP4Parser extends BasicParser {
       debug(`Chapter ${i + 1}: ${title}`);
       const chapter = {
         title,
+        timeScale: chapterTrack.timeScale,
+        start,
         sampleOffset: this.findSampleOffset(track, this.tokenizer.position)
       };
       debug(`Chapter title=${chapter.title}, offset=${chapter.sampleOffset}/${this.tracks[0].duration}`);

--- a/lib/mp4/MP4Parser.ts
+++ b/lib/mp4/MP4Parser.ts
@@ -541,7 +541,9 @@ export class MP4Parser extends BasicParser {
     }
     const chapters: IChapter[] = [];
     for (let i = 0; i < chapterTrack.chunkOffsetTable.length && len > 0; ++i) {
-      const start = chapterTrack.timeToSampleTable.slice(0, i ).reduce((acc, cur)=> acc + cur.duration, 0);
+      const start = chapterTrack.timeToSampleTable
+        .slice(0, i)
+        .reduce((acc, cur) => acc + cur.duration, 0);
 
       const chunkOffset = chapterTrack.chunkOffsetTable[i];  
       const nextChunkLen = chunkOffset - this.tokenizer.position;

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -521,6 +521,14 @@ export interface IChapter {
    * Duration offset is sampleOffset / format.sampleRate
    */
   sampleOffset: number;
+  /**
+   * Time where chapter starts
+   */
+  start: number;
+  /**
+   * 
+   */
+  timeScale: number;
 }
 
 /**

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -522,11 +522,12 @@ export interface IChapter {
    */
   sampleOffset: number;
   /**
-   * Time where chapter starts
+   * Timestamp where the chapter starts
+   * Chapter timestamp is start/timeScale in seconds.
    */
   start: number;
   /**
-   * Chapter track timescale
+   * Time value that indicates the time scale for chapter tracks, the number of time units that pass per second in its time coordinate system.
    */
   timeScale: number;
 }

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -526,7 +526,7 @@ export interface IChapter {
    */
   start: number;
   /**
-   * 
+   * Chapter track timescale
    */
   timeScale: number;
 }

--- a/test/test-file-mp4.ts
+++ b/test/test-file-mp4.ts
@@ -202,58 +202,86 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
           assert.deepEqual(format.chapters, [
             {
               sampleOffset: 45056,
+              timeScale: 44100,
+              start: 0,
               title: '01 - Baby\'s Opera: 01 - Girls and Boys'
             },
             {
               sampleOffset: 2695168,
+              timeScale: 44100, 
+              start: 2690214,
               title: '02 - Baby\'s Opera: 02 - The Mulberry Bush'
             },
             {
               sampleOffset: 5083136,
+              timeScale: 44100, 
+              start: 5072343,
               title: '03 - Baby\'s Opera: 03 - Oranges and Lemons'
             },
             {
               sampleOffset: 8352768,
+              timeScale: 44100, 
+              start: 8335466,
               title: '04 - Baby\'s Opera: 04 - St. Paul\'s Steeple'
             },
             {
               sampleOffset: 10544128,
+              timeScale: 44100, 
+              start: 10539994,
               title: '05 - Baby\'s Opera: 05 - My Lady\'s Garden'
             },
             {
               sampleOffset: 12284928,
+              timeScale: 44100, 
+              start: 12260367,
               title: '06 - Baby\'s Opera: 12 - Dickory Dock'
             },
             {
               sampleOffset: 14125056,
+              timeScale: 44100, 
+              start: 14112293,
               title: '07 - Baby\'s Opera: 22 - Baa!Baa!Black Sheep'
             },
             {
               sampleOffset: 16410624,
+              timeScale: 44100, 
+              start: 16405319,
               title: '08 - Baby\'s Bouquet: 01 - Dedication and Polly put the Kettle On'
             },
             {
               sampleOffset: 19068928,
+              timeScale: 44100, 
+              start: 19051667,
               title: '09 - Baby\'s Bouquet: 02 - Hot Cross Buns'
             },
             {
               sampleOffset: 21685248,
+              timeScale: 44100, 
+              start: 21653824,
               title: '10 - Baby\'s Bouquet: 03 - The Little Woman and the Pedlar'
             },
             {
               sampleOffset: 30461952,
+              timeScale: 44100, 
+              start: 30429742,
               title: '11 - Baby\'s Bouquet: 04 - The Little Disaster'
             },
             {
               sampleOffset: 37761024,
+              timeScale: 44100, 
+              start: 37750318,
               title: '12 - Baby\'s Bouquet: 05 - The Old Woman of Norwich'
             },
             {
               sampleOffset: 39628800,
+              timeScale: 44100, 
+              start: 39602731,
               title: '13 - Baby\'s Bouquet: 12 - Lucy Locket'
             },
             {
               sampleOffset: 41500672,
+              timeScale: 44100, 
+              start: 41498151,
               title: '14 - Baby\'s Bouquet: 18 - The North Wind & the Robin'
             }
           ]);

--- a/test/test-file-mp4.ts
+++ b/test/test-file-mp4.ts
@@ -208,79 +208,79 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
             },
             {
               sampleOffset: 2695168,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 2690214,
               title: '02 - Baby\'s Opera: 02 - The Mulberry Bush'
             },
             {
               sampleOffset: 5083136,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 5072343,
               title: '03 - Baby\'s Opera: 03 - Oranges and Lemons'
             },
             {
               sampleOffset: 8352768,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 8335466,
               title: '04 - Baby\'s Opera: 04 - St. Paul\'s Steeple'
             },
             {
               sampleOffset: 10544128,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 10539994,
               title: '05 - Baby\'s Opera: 05 - My Lady\'s Garden'
             },
             {
               sampleOffset: 12284928,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 12260367,
               title: '06 - Baby\'s Opera: 12 - Dickory Dock'
             },
             {
               sampleOffset: 14125056,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 14112293,
               title: '07 - Baby\'s Opera: 22 - Baa!Baa!Black Sheep'
             },
             {
               sampleOffset: 16410624,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 16405319,
               title: '08 - Baby\'s Bouquet: 01 - Dedication and Polly put the Kettle On'
             },
             {
               sampleOffset: 19068928,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 19051667,
               title: '09 - Baby\'s Bouquet: 02 - Hot Cross Buns'
             },
             {
               sampleOffset: 21685248,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 21653824,
               title: '10 - Baby\'s Bouquet: 03 - The Little Woman and the Pedlar'
             },
             {
               sampleOffset: 30461952,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 30429742,
               title: '11 - Baby\'s Bouquet: 04 - The Little Disaster'
             },
             {
               sampleOffset: 37761024,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 37750318,
               title: '12 - Baby\'s Bouquet: 05 - The Old Woman of Norwich'
             },
             {
               sampleOffset: 39628800,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 39602731,
               title: '13 - Baby\'s Bouquet: 12 - Lucy Locket'
             },
             {
               sampleOffset: 41500672,
-              timeScale: 44100, 
+              timeScale: 44100,
               start: 41498151,
               title: '14 - Baby\'s Bouquet: 18 - The North Wind & the Robin'
             }


### PR DESCRIPTION
Hello, I added the starting time and timescale values of chapters from audiobook file `.m4b`.
Unit test updated and matches values using ffprobe.

**Issues Found**

- `.m4b` with `isom/iso2/mp41` container only returns one chapter but all chapter durations are present.

  - In the `parseChapterTrack` function, `chapterTrack.chunkOffsetTable` only contains only one value, and `chapterTrack.sampleSizeTable` is empty. Which I believe they're needed to extract the chapter titles.

- `.m4b` with `M4A/isom/iso2`, it doesn't return any chapter lists.

I can provide the sample files I used if there's a way I can send them privately as they are copyrighted material.

Reading the buffer/token(?) values is not my currently strong suit but I hope this PR helps.