### PR TITLE
Set ASF duration according to the description.

### DIFF
--- a/lib/asf/AsfParser.ts
+++ b/lib/asf/AsfParser.ts
@@ -44,7 +44,7 @@ export class AsfParser extends BasicParser {
 
         case AsfObject.FilePropertiesObject.guid.str: // 3.2
           const fpo = await this.tokenizer.readToken<AsfObject.IFilePropertiesObject>(new AsfObject.FilePropertiesObject(header));
-          this.metadata.setFormat('duration', fpo.playDuration / 10000000);
+          this.metadata.setFormat('duration', fpo.playDuration / 10000000 - fpo.preroll / 1000);
           this.metadata.setFormat('bitrate', fpo.maximumBitrate);
           break;
 

--- a/test/test-file-asf.ts
+++ b/test/test-file-asf.ts
@@ -73,7 +73,7 @@ describe("Parse ASF", () => {
     function checkFormat(format) {
       assert.strictEqual(format.container, 'ASF/audio', 'format.container');
       assert.strictEqual(format.codec, 'Windows Media Audio 9.1', 'format.codec');
-      assert.strictEqual(format.duration, 244.885, 'format.duration');
+      assert.approximately(format.duration, 243.306, 1 / 10000, "format.duration");
       assert.strictEqual(format.bitrate, 192639, 'format.bitrate');
     }
 
@@ -137,7 +137,7 @@ describe("Parse ASF", () => {
 
       assert.strictEqual(format.container, 'ASF/audio', 'format.container');
       assert.strictEqual(format.codec, 'Windows Media Audio 9', 'format.codec');
-      assert.approximately(format.duration, 16.044, 1 / 10000, 'format.duration');
+      assert.approximately(format.duration, 14.466, 1 / 10000, 'format.duration');
       assert.approximately(format.bitrate, 128639, 1, 'format.bitrate');
 
       const asf = mm.orderTags(native.asf);

--- a/test/test-picard-parsing.ts
+++ b/test/test-picard-parsing.ts
@@ -612,7 +612,7 @@ describe('Parsing of metadata saved by \'Picard\' in audio files', () => {
       t.deepEqual(format.tagTypes, ['asf'], 'format.tagTypes = asf');
       t.strictEqual(format.bitrate, 320000, 'format.bitrate = 320000');
       // ToDo t.strictEqual(format.container, "wma", "format.container = wma");
-      t.strictEqual(format.duration, 5.235, 'format.duration'); // duration is wrong, but seems to be what is written in file
+      t.approximately(format.duration, 2.135, 1 / 10000, "format.duration");
       // ToDo t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       // ToDo t.strictEqual(format.bitsPerSample, 16, 'format.bitsPerSample'); // ToDo
       // ToDo t.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels'); // ToDo


### PR DESCRIPTION
Description of _preroll_ field says:

> Specifies the amount of time to buffer data before starting to play the file, in millisecond units. If this value is nonzero, the Play Duration field and all of the payload Presentation Time fields have been offset by this amount. **Therefore, player software must subtract the value in the preroll field from the play duration and presentation times to calculate their actual values**. It follows that all payload Presentation Time fields need to be at least this value.

I created a pull request to fix duration value, so now for .wma files we have same value as displayed in file's properties -> details.