### PR TITLE
Update token-types to v3 utilizing BigInt

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
 

--- a/lib/asf/AsfObject.ts
+++ b/lib/asf/AsfObject.ts
@@ -74,7 +74,7 @@ export const TopLevelHeaderObjectToken: IGetToken<IAsfTopLevelObjectHeader> = {
   get: (buf, off): IAsfTopLevelObjectHeader => {
     return {
       objectId: GUID.fromBin(new Token.BufferType(16).get(buf, off)),
-      objectSize: Token.UINT64_LE.get(buf, off + 16),
+      objectSize: Number(Token.UINT64_LE.get(buf, off + 16)),
       numberOfHeaderObjects: Token.UINT32_LE.get(buf, off + 24)
       // Reserved: 2 bytes
     };
@@ -92,7 +92,7 @@ export const HeaderObjectToken: IGetToken<IAsfObjectHeader> = {
   get: (buf, off): IAsfObjectHeader => {
     return {
       objectId: GUID.fromBin(new Token.BufferType(16).get(buf, off)),
-      objectSize: Token.UINT64_LE.get(buf, off + 16)
+      objectSize: Number(Token.UINT64_LE.get(buf, off + 16))
     };
   }
 };
@@ -102,7 +102,7 @@ export abstract class State<T> implements IGetToken<T> {
   public len: number;
 
   constructor(header: IAsfObjectHeader) {
-    this.len = header.objectSize - HeaderObjectToken.len;
+    this.len = Number(header.objectSize) - HeaderObjectToken.len;
   }
 
   public abstract get(buf: Buffer, off: number): T;
@@ -150,31 +150,31 @@ export interface IFilePropertiesObject {
    * Specifies the size, in bytes, of the entire file.
    * The value of this field is invalid if the Broadcast Flag bit in the Flags field is set to 1.
    */
-  fileSize: number,
+  fileSize: bigint,
   /**
    * Specifies the date and time of the initial creation of the file. The value is given as the number of 100-nanosecond
    * intervals since January 1, 1601, according to Coordinated Universal Time (Greenwich Mean Time). The value of this
    * field may be invalid if the Broadcast Flag bit in the Flags field is set to 1.
    */
-  creationDate: number,
+  creationDate: bigint,
   /**
    * Specifies the number of Data Packet entries that exist within the Data Object. The value of this field is invalid
    * if the Broadcast Flag bit in the Flags field is set to 1.
    */
-  dataPacketsCount: number,
+  dataPacketsCount: bigint,
   /**
    * Specifies the time needed to play the file in 100-nanosecond units.
    * This value should include the duration (estimated, if an exact value is unavailable) of the the last media object
    * in the presentation. The value of this field is invalid if the Broadcast Flag bit in the Flags field is set to 1.
    */
-  playDuration: number,
+  playDuration: bigint,
   /**
    * Specifies the time needed to send the file in 100-nanosecond units.
    * This value should include the duration of the last packet in the content.
    * The value of this field is invalid if the Broadcast Flag bit in the Flags field is set to 1.
    * Players can ignore this value.
    */
-  sendDuration: number,
+  sendDuration: bigint,
   /**
    * Specifies the amount of time to buffer data before starting to play the file, in millisecond units.
    * If this value is nonzero, the Play Duration field and all of the payload Presentation Time fields have been offset
@@ -182,7 +182,7 @@ export interface IFilePropertiesObject {
    * presentation times to calculate their actual values. It follows that all payload Presentation Time fields need to
    * be at least this value.
    */
-  preroll: number,
+  preroll: bigint,
   /**
    * The flags
    */
@@ -481,8 +481,8 @@ export interface IStreamName {
  * Ref: http://drang.s4.xrea.com/program/tips/id3tag/wmp/04_objects_in_the_asf_header_extension_object.html#4_1
  */
 export interface IExtendedStreamPropertiesObject {
-  startTime: number,
-  endTime: number,
+  startTime: bigint,
+  endTime: bigint,
   dataBitrate: number,
   bufferSize: number,
   initialBufferFullness: number,

--- a/lib/asf/AsfParser.ts
+++ b/lib/asf/AsfParser.ts
@@ -44,7 +44,7 @@ export class AsfParser extends BasicParser {
 
         case AsfObject.FilePropertiesObject.guid.str: // 3.2
           const fpo = await this.tokenizer.readToken<AsfObject.IFilePropertiesObject>(new AsfObject.FilePropertiesObject(header));
-          this.metadata.setFormat('duration', fpo.playDuration / 10000000 - fpo.preroll / 1000);
+          this.metadata.setFormat('duration',  Number(fpo.playDuration / BigInt(1000)) / 10000 - Number(fpo.preroll) / 1000);
           this.metadata.setFormat('bitrate', fpo.maximumBitrate);
           break;
 
@@ -111,6 +111,7 @@ export class AsfParser extends BasicParser {
     do {
       // Parse common header of the ASF Object (3.1)
       const header = await this.tokenizer.readToken<AsfObject.IAsfObjectHeader>(AsfObject.HeaderObjectToken);
+      const remaining = header.objectSize - AsfObject.HeaderObjectToken.len;
       // Parse data part of the ASF Object
       switch (header.objectId.str) {
 
@@ -131,15 +132,15 @@ export class AsfParser extends BasicParser {
 
         case GUID.PaddingObject.str:
           // ToDo: register bytes pad
-          await this.tokenizer.ignore(header.objectSize - AsfObject.HeaderObjectToken.len);
+          await this.tokenizer.ignore(remaining);
           break;
 
         case GUID.CompatibilityObject.str:
-          this.tokenizer.ignore(header.objectSize - AsfObject.HeaderObjectToken.len);
+          this.tokenizer.ignore(remaining);
           break;
 
         case GUID.ASF_Index_Placeholder_Object.str:
-          await this.tokenizer.ignore(header.objectSize - AsfObject.HeaderObjectToken.len);
+          await this.tokenizer.ignore(remaining);
           break;
 
         default:

--- a/lib/asf/AsfUtil.ts
+++ b/lib/asf/AsfUtil.ts
@@ -2,7 +2,7 @@ import common from "../common/Util";
 import {DataType} from "./AsfObject";
 import * as Token from "token-types";
 
-export type AttributeParser = (buf: Buffer) => boolean | string | number | Buffer;
+export type AttributeParser = (buf: Buffer) => boolean | string | number | bigint | Buffer;
 
 export class AsfUtil {
 
@@ -38,7 +38,7 @@ export class AsfUtil {
     return buf.readUInt32LE(offset);
   }
 
-  private static parseQWordAttr(buf: Buffer, offset: number = 0): number {
+  private static parseQWordAttr(buf: Buffer, offset: number = 0): bigint {
     return Token.UINT64_LE.get(buf, offset);
   }
 

--- a/lib/dsdiff/DsdiffToken.ts
+++ b/lib/dsdiff/DsdiffToken.ts
@@ -1,18 +1,18 @@
 import * as Token from 'token-types';
 import { FourCcToken } from '../common/FourCC';
-import { IChunkHeader } from '../iff';
+import { IChunkHeader64 } from '../iff';
 import { IGetToken } from 'strtok3/lib/core';
-export { IChunkHeader } from '../iff';
+export { IChunkHeader64 } from '../iff';
 
 /**
  * DSDIFF chunk header
  * The data-size encoding is deviating from EA-IFF 85
  * Ref: http://www.sonicstudio.com/pdf/dsd/DSDIFF_1.5_Spec.pdf
  */
-export const ChunkHeader: IGetToken<IChunkHeader> = {
+export const ChunkHeader64: IGetToken<IChunkHeader64> = {
   len: 12,
 
-  get: (buf, off): IChunkHeader => {
+  get: (buf, off): IChunkHeader64 => {
     return {
       // Group-ID
       chunkID: FourCcToken.get(buf, off),

--- a/lib/dsf/DsfChunk.ts
+++ b/lib/dsf/DsfChunk.ts
@@ -15,7 +15,7 @@ export interface IChunkHeader {
   /**
    * Chunk size
    */
-  size: number;
+  size: bigint;
 }
 
 /**
@@ -37,13 +37,13 @@ export interface IDsdChunk {
   /**
    * Total file size
    */
-  fileSize: number;
+  fileSize: bigint;
 
   /**
    * If Metadata doesn’t exist, set 0. If the file has ID3v2 tag, then set the pointer to it.
    * ID3v2 tag should be located in the end of the file.
    */
-  metadataPointer: number;
+  metadataPointer: bigint;
 }
 
 /**
@@ -109,7 +109,7 @@ export interface IFormatChunk {
   /**
    * Sample count
    */
-  sampleCount: number;
+  sampleCount: bigint;
 
   /**
    * Block size per channel

--- a/lib/dsf/DsfParser.ts
+++ b/lib/dsf/DsfParser.ts
@@ -21,18 +21,18 @@ export class DsfParser extends AbstractID3Parser {
     this.metadata.setFormat('container', 'DSF');
     this.metadata.setFormat('lossless', true);
     const dsdChunk = await this.tokenizer.readToken<IDsdChunk>(DsdChunk);
-    if (dsdChunk.metadataPointer === 0) {
+    if (dsdChunk.metadataPointer === BigInt(0)) {
       debug(`No ID3v2 tag present`);
     } else {
       debug(`expect ID3v2 at offset=${dsdChunk.metadataPointer}`);
       await this.parseChunks(dsdChunk.fileSize - chunkHeader.size);
       // Jump to ID3 header
-      await this.tokenizer.ignore(dsdChunk.metadataPointer - this.tokenizer.position - p0);
+      await this.tokenizer.ignore(Number(dsdChunk.metadataPointer) - this.tokenizer.position - p0);
       return new ID3v2Parser().parse(this.metadata, this.tokenizer, this.options);
     }
   }
 
-  private async parseChunks(bytesRemaining: number) {
+  private async parseChunks(bytesRemaining: bigint) {
     while (bytesRemaining >= ChunkHeader.len) {
       const chunkHeader = await this.tokenizer.readToken<IChunkHeader>(ChunkHeader);
       debug(`Parsing chunk name=${chunkHeader.id} size=${chunkHeader.size}`);
@@ -43,12 +43,12 @@ export class DsfParser extends AbstractID3Parser {
           this.metadata.setFormat('sampleRate', formatChunk.samplingFrequency);
           this.metadata.setFormat('bitsPerSample', formatChunk.bitsPerSample);
           this.metadata.setFormat('numberOfSamples', formatChunk.sampleCount);
-          this.metadata.setFormat('duration', formatChunk.sampleCount / formatChunk.samplingFrequency);
+          this.metadata.setFormat('duration', Number(formatChunk.sampleCount) / formatChunk.samplingFrequency);
           const bitrate = formatChunk.bitsPerSample * formatChunk.samplingFrequency * formatChunk.channelNum;
           this.metadata.setFormat('bitrate', bitrate);
           return; // We got what we want, stop further processing of chunks
         default:
-          this.tokenizer.ignore(chunkHeader.size - ChunkHeader.len);
+          this.tokenizer.ignore(Number(chunkHeader.size) - ChunkHeader.len);
           break;
       }
       bytesRemaining -= chunkHeader.size;

--- a/lib/iff/index.ts
+++ b/lib/iff/index.ts
@@ -18,6 +18,22 @@ export interface IChunkHeader {
 }
 
 /**
+ * "EA IFF 85" Standard for Interchange Format Files
+ * Ref: http://www.martinreddy.net/gfx/2d/IFF.txt
+ */
+export interface IChunkHeader64 {
+
+  /**
+   * 	A chunk ID (ie, 4 ASCII bytes)
+   */
+  chunkID: string,
+  /**
+   * Number of data bytes following this data header
+   */
+  chunkSize: bigint
+}
+
+/**
  * Common AIFF chunk header
  */
 export const Header: IGetToken<IChunkHeader> = {
@@ -32,3 +48,4 @@ export const Header: IGetToken<IChunkHeader> = {
     };
   }
 };
+

--- a/lib/mp4/Atom.ts
+++ b/lib/mp4/Atom.ts
@@ -15,11 +15,11 @@ export class Atom {
     const offset = tokenizer.position;
     // debug(`Reading next token on offset=${offset}...`); //  buf.toString('ascii')
     const header = await tokenizer.readToken<AtomToken.IAtomHeader>(AtomToken.Header);
-    const extended = header.length === 1;
+    const extended = header.length === BigInt(1);
     if (extended) {
-      header.length = await tokenizer.readToken<number>(AtomToken.ExtendedSize);
+      header.length = await tokenizer.readToken<bigint>(AtomToken.ExtendedSize);
     }
-    const atomBean = new Atom(header, header.length === 1, parent);
+    const atomBean = new Atom(header, header.length === BigInt(1), parent);
     const payloadLength = atomBean.getPayloadLength(remaining);
     debug(`parse atom name=${atomBean.atomPath}, extended=${atomBean.extended}, offset=${offset}, len=${atomBean.header.length}`); //  buf.toString('ascii')
     await atomBean.readData(tokenizer, dataHandler, payloadLength);
@@ -39,14 +39,14 @@ export class Atom {
   }
 
   public getPayloadLength(remaining: number): number {
-    return (this.header.length === 0 ? remaining : this.header.length) - this.getHeaderLength();
+    return (this.header.length === BigInt(0) ? remaining : Number(this.header.length)) - this.getHeaderLength();
   }
 
   public async readAtoms(tokenizer: ITokenizer, dataHandler: AtomDataHandler, size: number): Promise<void> {
     while (size > 0) {
       const atomBean = await Atom.readAtom(tokenizer, dataHandler, this, size);
       this.children.push(atomBean);
-      size -= atomBean.header.length === 0 ? size : atomBean.header.length;
+      size -= atomBean.header.length === BigInt(0) ? size : Number(atomBean.header.length);
     }
   }
 

--- a/lib/mp4/AtomToken.ts
+++ b/lib/mp4/AtomToken.ts
@@ -19,7 +19,7 @@ interface IVersionAndFlags {
 }
 
 export interface IAtomHeader {
-  length: number,
+  length: bigint,
   name: string
 }
 
@@ -142,13 +142,13 @@ export const Header: IToken<IAtomHeader> = {
       throw new Error('Invalid atom header length');
 
     return {
-      length,
+      length: BigInt(length),
       name: new Token.StringType(4, 'binary').get(buf, off + 4)
     };
   },
 
   put: (buf: Buffer, off: number, hdr: IAtomHeader) => {
-    Token.UINT32_BE.put(buf, off, hdr.length);
+    Token.UINT32_BE.put(buf, off, Number(hdr.length));
     return FourCcToken.put(buf, off + 4, hdr.name);
   }
 };
@@ -156,7 +156,7 @@ export const Header: IToken<IAtomHeader> = {
 /**
  * Ref: https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap1/qtff1.html#//apple_ref/doc/uid/TP40000939-CH203-38190
  */
-export const ExtendedSize = Token.UINT64_BE;
+export const ExtendedSize: IToken<bigint> = Token.UINT64_BE;
 
 export const ftyp: IGetToken<IAtomFtyp> = {
   len: 4,
@@ -186,7 +186,7 @@ export const mhdr: IGetToken<IMovieHeaderAtom> = {
 
   get: (buf: Buffer, off: number): IMovieHeaderAtom => {
     return {
-      version: Token.UINT8.get(buf, off + 0),
+      version: Token.UINT8.get(buf, off),
       flags: Token.UINT24_BE.get(buf, off + 1),
       nextItemID: Token.UINT32_BE.get(buf, off + 4)
     };

--- a/package.json
+++ b/package.json
@@ -87,8 +87,8 @@
     "debug": "^4.3.1",
     "file-type": "^16.5.0",
     "media-typer": "^1.1.0",
-    "strtok3": "^6.0.8",
-    "token-types": "^2.1.1"
+    "strtok3": "^6.1.1",
+    "token-types": "^3.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.18",
@@ -112,7 +112,7 @@
     "typescript": "^4.3.2"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",

--- a/test/test-file-asf.ts
+++ b/test/test-file-asf.ts
@@ -61,7 +61,7 @@ describe("Parse ASF", () => {
 
     tests.forEach(test => {
       const buf = Buffer.from(test.raw, "binary");
-      assert.strictEqual(AsfUtil.getParserForAttr(DataType.QWord)(buf), test.expected, test.description);
+      assert.strictEqual(Number(AsfUtil.getParserForAttr(DataType.QWord)(buf)), test.expected, test.description);
     });
 
   });

--- a/test/test-file-dsf.ts
+++ b/test/test-file-dsf.ts
@@ -14,19 +14,19 @@ describe('Parse Sony DSF (DSD Stream File)', () => {
 
     // format chunk information
     assert.strictEqual(metadata.format.container, 'DSF');
-    assert.deepEqual(metadata.format.lossless, true);
-    assert.deepEqual(metadata.format.numberOfChannels, 2);
-    assert.deepEqual(metadata.format.bitsPerSample, 1);
-    assert.deepEqual(metadata.format.sampleRate, 5644800);
-    assert.deepEqual(metadata.format.numberOfSamples, 564480);
-    assert.deepEqual(metadata.format.duration, 0.1);
-    assert.deepEqual(metadata.format.bitrate, 11289600);
-    assert.deepEqual(metadata.format.tagTypes, ['ID3v2.3']);
+    assert.strictEqual(metadata.format.lossless, true);
+    assert.strictEqual(metadata.format.numberOfChannels, 2);
+    assert.strictEqual(metadata.format.bitsPerSample, 1);
+    assert.strictEqual(metadata.format.sampleRate, 5644800);
+    assert.strictEqual(Number(metadata.format.numberOfSamples), 564480);
+    assert.strictEqual(metadata.format.duration, 0.1);
+    assert.strictEqual(metadata.format.bitrate, 11289600);
+    assert.deepStrictEqual(metadata.format.tagTypes, ['ID3v2.3']);
 
     // ID3v2 chunk information
     assert.strictEqual(metadata.common.title, 'Kyrie');
     assert.strictEqual(metadata.common.artist, 'CANTUS (Tove Ramlo-Ystad) & Frode Fjellheim');
-    assert.deepEqual(metadata.common.track, {no: 4, of: 12});
+    assert.deepStrictEqual(metadata.common.track, {no: 4, of: 12});
   });
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,6 +214,11 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
+"@types/debug@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.6.tgz#0b7018723084918a865eff99249c490505df2163"
+  integrity sha512-7fDOJFA/x8B+sO1901BmHlf5dE1cxBU8mRXj8QOEDnn16hhGJv/IHxJtZhvsabZsIMn0eLIyeOKAeqSNJJYTpA==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -3100,13 +3105,22 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-strtok3@^6.0.3, strtok3@^6.0.8:
+strtok3@^6.0.3:
   version "6.0.8"
   resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.8.tgz#c839157f615c10ba0f4ae35067dad9959eeca346"
   integrity sha512-QLgv+oiXwXgCgp2PdPPa+Jpp4D9imK9e/0BsyfeFMr6QL6wMVqoVn9+OXQ9I7MZbmUzN6lmitTJ09uwS2OmGcw==
   dependencies:
     "@tokenizer/token" "^0.1.1"
     "@types/debug" "^4.1.5"
+    peek-readable "^3.1.3"
+
+strtok3@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.1.1.tgz#4e948b5bffeee4c66504c73625a28b170d45ae45"
+  integrity sha512-Q2YbTf17/GPyhWnYGPcxZdPuXvVvstHEKdgxgdaj+SI2c5//KezIgAQJAT2/RYI0H+CQt2fDVvPiLBdl82i0yA==
+  dependencies:
+    "@tokenizer/token" "^0.1.1"
+    "@types/debug" "^4.1.6"
     peek-readable "^3.1.3"
 
 supports-color@6.0.0:
@@ -3183,10 +3197,18 @@ to-vfile@^6.0.0:
     is-buffer "^2.0.0"
     vfile "^4.0.0"
 
-token-types@^2.0.0, token-types@^2.1.1:
+token-types@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/token-types/-/token-types-2.1.1.tgz#bd585d64902aaf720b8979d257b4b850b4d45c45"
   integrity sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==
+  dependencies:
+    "@tokenizer/token" "^0.1.1"
+    ieee754 "^1.2.1"
+
+token-types@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-3.0.0.tgz#982fb4e705103bc647fd281b06de213ea06ce65a"
+  integrity sha512-1cV7R6TRKfCG1++se5xGy9fUpD+L1u/7XgmViGA1Y5bubHt6W4w1r1j0uOk+5ngM6yhssRJ+qR+IaviVgAizJA==
   dependencies:
     "@tokenizer/token" "^0.1.1"
     ieee754 "^1.2.1"


### PR DESCRIPTION
BigInt requires Node version 10, updated module engine API requirement.
Update strtok3 to v6.1.0 to allign the dependent token-types version.