### PR TITLE
Corrected type for bpm property

### DIFF
--- a/lib/type.ts
+++ b/lib/type.ts
@@ -172,7 +172,7 @@ export interface ICommonTagsResult {
   movementTotal?: number;
   compilation?: boolean;
   rating?: IRating[];
-  bpm?: number;
+  bpm?: string;
   /**
    * Keywords to reflect the mood of the audio, e.g. 'Romantic' or 'Sad'
    */


### PR DESCRIPTION
The `bpm` property actually comes back as a string when using `parseFile`, `parseStream`, etc.