### PR TITLE
Define default module exports

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -68,3 +68,14 @@ export const orderTags = Core.orderTags;
  * @returns Number of stars: 1, 2, 3, 4 or 5 stars
  */
 export const ratingToStars = Core.ratingToStars;
+
+/**
+ * Define default module exports
+ */
+export default {
+  parseStream,
+  parseFile,
+  parseFromTokenizer: Core.parseFromTokenizer,
+  parseBuffer: Core.parseBuffer,
+  selectCover: Core.selectCover
+};


### PR DESCRIPTION
Allow default import:
```js
import musicMetadata from 'music-metadata'
```
instead of
```js
import * as musicMetadata from 'music-metadata'
```

In favor of staniel359/muffon#36