### PR TITLE
Handle case where Matroska tag target doesn't exist

### DIFF
--- a/lib/matroska/MatroskaParser.ts
+++ b/lib/matroska/MatroskaParser.ts
@@ -108,7 +108,7 @@ export class MatroskaParser extends BasicParser {
         if (matroska.segment.tags) {
           matroska.segment.tags.tag.forEach(tag => {
             const target = tag.target;
-            const targetType = target.targetTypeValue ? TargetType[target.targetTypeValue] : (target.targetType ? target.targetType : 'track');
+            const targetType = target?.targetTypeValue ? TargetType[target.targetTypeValue] : (target?.targetType ? target.targetType : 'track');
             tag.simpleTags.forEach(simpleTag => {
               const value = simpleTag.string ? simpleTag.string : simpleTag.binary;
               this.addTag(`${targetType}:${simpleTag.name}`, value);


### PR DESCRIPTION
(Ab)using this library to extract tags from MKV files since it's the best Matroska parser I can find. Ran into an edge case where `tag.target` wasn't always present. I was able to fix by tweaking the logic slightly. Not sure you'll ever run into this in music files, but figured I'd open a PR just in case. Cheers!