### PR TITLE
Minor code improvements in ASF & MPEG parser

### DIFF
--- a/lib/asf/AsfObject.ts
+++ b/lib/asf/AsfObject.ts
@@ -557,8 +557,9 @@ export class MetadataObjectState extends State<ITag[]> {
     super(header);
   }
 
-  public get(buf: Buffer, off: number): ITag[] {
+  public get(uint8Array: Uint8Array, off: number): ITag[] {
     const tags: ITag[] = [];
+    const buf = Buffer.from(uint8Array);
     const descriptionRecordsCount = buf.readUInt16LE(off);
     let pos = off + 2;
     for (let i = 0; i < descriptionRecordsCount; i += 1) {
@@ -573,10 +574,6 @@ export class MetadataObjectState extends State<ITag[]> {
       pos += nameLen;
       const data = buf.slice(pos, pos + dataLen);
       pos += dataLen;
-      const parseAttr = AsfUtil.getParserForAttr(dataType);
-      if (!parseAttr) {
-        throw new Error('unexpected value headerType: ' + dataType);
-      }
       this.postProcessTag(tags, name, dataType, data);
     }
     return tags;

--- a/lib/asf/AsfUtil.ts
+++ b/lib/asf/AsfUtil.ts
@@ -11,8 +11,8 @@ export class AsfUtil {
     return AsfUtil.attributeParsers[i];
   }
 
-  public static parseUnicodeAttr(buf): string {
-    return util.stripNulls(util.decodeString(buf, 'utf16le'));
+  public static parseUnicodeAttr(uint8Array: Uint8Array): string {
+    return util.stripNulls(util.decodeString(uint8Array, 'utf16le'));
   }
 
   private static attributeParsers: AttributeParser[] = [
@@ -25,10 +25,8 @@ export class AsfUtil {
     AsfUtil.parseByteArrayAttr
   ];
 
-  private static parseByteArrayAttr(buf: Buffer): Buffer {
-    const newBuf = Buffer.alloc(buf.length);
-    buf.copy(newBuf);
-    return newBuf;
+  private static parseByteArrayAttr(buf: Uint8Array): Buffer {
+    return Buffer.from(buf);
   }
 
   private static parseBoolAttr(buf: Buffer, offset: number = 0): boolean {

--- a/lib/common/Util.ts
+++ b/lib/common/Util.ts
@@ -86,16 +86,16 @@ export function stripNulls(str: string): string {
 /**
  * Read bit-aligned number start from buffer
  * Total offset in bits = byteOffset * 8 + bitOffset
- * @param buf Byte buffer
+ * @param source Byte buffer
  * @param byteOffset Starting offset in bytes
  * @param bitOffset Starting offset in bits: 0 = lsb
  * @param len Length of number in bits
- * @return {number} decoded bit aligned number
+ * @return Decoded bit aligned number
  */
-export function getBitAllignedNumber(buf: Uint8Array, byteOffset: number, bitOffset: number, len: number): number {
+export function getBitAllignedNumber(source: Uint8Array, byteOffset: number, bitOffset: number, len: number): number {
   const byteOff = byteOffset + ~~(bitOffset / 8);
   const bitOff = bitOffset % 8;
-  let value = buf[byteOff];
+  let value = source[byteOff];
   value &= 0xff >> bitOff;
   const bitsRead = 8 - bitOff;
   const bitsLeft = len - bitsRead;
@@ -103,7 +103,7 @@ export function getBitAllignedNumber(buf: Uint8Array, byteOffset: number, bitOff
     value >>= (8 - bitOff - len);
   } else if (bitsLeft > 0) {
     value <<= bitsLeft;
-    value |= getBitAllignedNumber(buf, byteOffset, bitOffset + bitsRead, bitsLeft);
+    value |= getBitAllignedNumber(source, byteOffset, bitOffset + bitsRead, bitsLeft);
   }
   return value;
 }
@@ -111,13 +111,13 @@ export function getBitAllignedNumber(buf: Uint8Array, byteOffset: number, bitOff
 /**
  * Read bit-aligned number start from buffer
  * Total offset in bits = byteOffset * 8 + bitOffset
- * @param buf Byte buffer
+ * @param source Byte Uint8Array
  * @param byteOffset Starting offset in bytes
- * @param bitOffset Starting offset in bits: 0 = most significant bit, 7 is least significant bit
- * @return {number} decoded bit aligned number
+ * @param bitOffset Starting offset in bits: 0 = most significant bit, 7 is the least significant bit
+ * @return True if bit is set
  */
-export function isBitSet(buf: Uint8Array, byteOffset: number, bitOffset: number): boolean {
-  return getBitAllignedNumber(buf, byteOffset, bitOffset, 1) === 1;
+export function isBitSet(source: Uint8Array, byteOffset: number, bitOffset: number): boolean {
+  return getBitAllignedNumber(source, byteOffset, bitOffset, 1) === 1;
 }
 
 export function a2hex(str: string) {


### PR DESCRIPTION
Use [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) in favor of [`Buffer`](https://nodejs.org/api/buffer.html), and covert to Buffer if required, like for text decoding.