### PR TITLE
Register a warning if a APEv2 reserved data-type (3) is used.

### DIFF
--- a/lib/apev2/APEv2Parser.ts
+++ b/lib/apev2/APEv2Parser.ts
@@ -172,8 +172,11 @@ export class APEv2Parser extends BasicParser {
           await this.tokenizer.ignore(tagItemHeader.size);
           break;
 
-        default:
-          throw new Error(`Unexpected data-type: ${tagItemHeader.flags.dataType}`);
+        case DataType.reserved:
+          debug(`Ignore external info ${key}`);
+          this.metadata.addWarning(`APEv2 header declares a reserved datatype for "${key}"`);
+          await this.tokenizer.ignore(tagItemHeader.size);
+          break;
       }
     }
   }


### PR DESCRIPTION
Resolves #1041