### PR TITLE
Fix TextEncodingToken, to use Uint8Array

### DIFF
--- a/lib/id3v2/ID3v2Token.ts
+++ b/lib/id3v2/ID3v2Token.ts
@@ -136,8 +136,8 @@ export interface ITextEncoding {
 export const TextEncodingToken: IGetToken<ITextEncoding> = {
   len: 1,
 
-  get: (buf: Buffer, off: number): ITextEncoding => {
-    switch (buf.readUInt8(off)) {
+  get: (uint8Array: Uint8Array, off: number): ITextEncoding => {
+    switch (uint8Array[off]) {
       case 0x00:
         return {encoding: 'latin1'}; // binary
       case 0x01:


### PR DESCRIPTION
Fix `TextEncodingToken`, to use `Uint8Array`, compliant with it's implementing interface.

Fixes #1066 