### PR TITLE
Ability to handle MP4 `meta` atom without 4 bytes padding

### DIFF
--- a/lib/mp4/Atom.ts
+++ b/lib/mp4/Atom.ts
@@ -1,5 +1,6 @@
 import initDebug from 'debug';
 import * as AtomToken from './AtomToken.js';
+import { Header } from './AtomToken.js';
 
 import { ITokenizer } from 'strtok3/core';
 
@@ -66,8 +67,10 @@ export class Atom {
 
       case 'meta': // Metadata Atom, ref: https://developer.apple.com/library/content/documentation/QuickTime/QTFF/Metadata/Metadata.html#//apple_ref/doc/uid/TP40000939-CH1-SW8
         // meta has 4 bytes of padding, ignore
-        await tokenizer.ignore(4);
-        return this.readAtoms(tokenizer, dataHandler, this.getPayloadLength(remaining) - 4);
+        const peekHeader = await tokenizer.peekToken(Header);
+        const paddingLength = peekHeader.name === 'hdlr' ? 0 : 4;
+        await tokenizer.ignore(paddingLength);
+        return this.readAtoms(tokenizer, dataHandler, this.getPayloadLength(remaining) - paddingLength);
 
       case 'mdhd': // Media header atom
       case 'mvhd': // 'movie' => 'mvhd': movie header atom; child of Movie Atom


### PR DESCRIPTION
Workaround for issue #1390