### PR TITLE
Release Date tag support

### DIFF
--- a/doc-gen/common.json
+++ b/doc-gen/common.json
@@ -1,6 +1,6 @@
 {
   "year": {
-    "description": "Release year"
+    "description": "Year"
   },
   "track": {
     "description": "Track number on the media, e.g. `{no: 1, of: 2}`"
@@ -48,13 +48,16 @@
     "description": "_ToDo, see [issues #13](https://github.com/Borewit/music-metadata/issues/13)_"
   },
   "date": {
-    "description": "Release date"
+    "description": "Date, formatted like: YYYY-MM-DD"
   },
   "originaldate": {
     "description": "Original (initial) release date, formatted like: YYYY-MM-DD"
   },
   "originalyear": {
     "description": "Original (initial) release year"
+  },
+    "releasedate": {
+    "description": "Release date, formatted like: YYYY-MM-DD"
   },
   "comment": {
     "description": "Comments"

--- a/lib/apev2/APEv2TagMapper.ts
+++ b/lib/apev2/APEv2TagMapper.ts
@@ -13,6 +13,7 @@ const apev2TagMap: INativeTagMap = {
   Year: 'date',
   Originalyear: 'originalyear',
   Originaldate: 'originaldate',
+  Releasedate: 'releasedate',
   Comment: 'comment',
   Track: 'track',
   Disc: 'disk',

--- a/lib/common/GenericTagTypes.ts
+++ b/lib/common/GenericTagTypes.ts
@@ -150,6 +150,7 @@ export const commonTags: ITagInfoMap = {
   date: {multiple: false},
   originaldate: {multiple: false},
   originalyear: {multiple: false},
+  releasedate: {multiple: false},
   comment: {multiple: true, unique: false},
   genre: {multiple: true, unique: true},
   picture: {multiple: true, unique: true},

--- a/lib/common/GenericTagTypes.ts
+++ b/lib/common/GenericTagTypes.ts
@@ -17,6 +17,7 @@ export type GenericTagId =
   | 'date'
   | 'originaldate'
   | 'originalyear'
+  | 'releasedate'
   | 'comment'
   | 'genre'
   | 'picture'

--- a/lib/id3v2/ID3v24TagMapper.ts
+++ b/lib/id3v2/ID3v24TagMapper.ts
@@ -93,7 +93,6 @@ const id3v24TagMap: INativeTagMap = {
   TDRC: 'date', // date YYYY-MM-DD
   TYER: 'year',
   TDOR: 'originaldate',
-  TDRL: 'releasedate',
   // 'TMCL:instrument': 'performer:instrument',
   'TIPL:arranger': 'arranger',
   'TIPL:engineer': 'engineer',
@@ -146,7 +145,7 @@ const id3v24TagMap: INativeTagMap = {
   PCST: 'podcast',
   TCAT: 'category',
   TDES: 'description',
-  TDRL: 'date',
+  TDRL: 'releasedate',
   TGID: 'podcastId',
   TKWD: 'keywords',
   WFED: 'podcasturl'

--- a/lib/id3v2/ID3v24TagMapper.ts
+++ b/lib/id3v2/ID3v24TagMapper.ts
@@ -93,6 +93,7 @@ const id3v24TagMap: INativeTagMap = {
   TDRC: 'date', // date YYYY-MM-DD
   TYER: 'year',
   TDOR: 'originaldate',
+  TDRL: 'releasedate',
   // 'TMCL:instrument': 'performer:instrument',
   'TIPL:arranger': 'arranger',
   'TIPL:engineer': 'engineer',

--- a/lib/matroska/MatroskaTagMapper.ts
+++ b/lib/matroska/MatroskaTagMapper.ts
@@ -10,6 +10,7 @@ const ebmlTagMap: INativeTagMap = {
   'album:ARTISTSORT': 'albumartistsort',
   'album:TITLE': 'album',
   'album:DATE_RECORDED': 'originaldate',
+  'album:DATE_RELEASED': 'releasedate',
   'album:PART_NUMBER': 'disk',
   'album:TOTAL_PARTS': 'totaltracks',
   'track:ARTIST': 'artist',

--- a/lib/mp4/MP4TagMapper.ts
+++ b/lib/mp4/MP4TagMapper.ts
@@ -92,6 +92,7 @@ const mp4TagMap: INativeTagMap = {
   '----:com.apple.iTunes:ARTISTS': 'artists',
   '----:com.apple.iTunes:ORIGINALDATE': 'originaldate',
   '----:com.apple.iTunes:ORIGINALYEAR': 'originalyear',
+  '----:com.apple.iTunes:RELEASEDATE': 'releasedate',
   // '----:com.apple.iTunes:PERFORMER': 'performer'
   desc: 'description',
   ldes: 'longDescription',

--- a/lib/ogg/vorbis/VorbisTagMapper.ts
+++ b/lib/ogg/vorbis/VorbisTagMapper.ts
@@ -20,6 +20,7 @@ const vorbisTagMap: INativeTagMap = {
   DATE: 'date',
   ORIGINALDATE: 'originaldate',
   ORIGINALYEAR: 'originalyear',
+  RELEASEDATE: 'releasedate',
   COMMENT: 'comment',
   TRACKNUMBER: 'track',
   DISCNUMBER: 'disk',

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -74,7 +74,7 @@ export interface ICommonTagsResult {
    */
   album?: string;
   /**
-   * Release data
+   * Date
    */
   date?: string;
   /**
@@ -82,9 +82,13 @@ export interface ICommonTagsResult {
    */
   originaldate?: string;
   /**
-   * Original release yeat
+   * Original release year
    */
   originalyear?: number;
+  /**
+   * Release date
+   */
+  releasedate?: string;
   /**
    * List of comments
    */


### PR DESCRIPTION
Smal fix for the Release Date (`TDRL`) frame as per [id3v2.4](https://github.com/id3/ID3v2.4/blob/516075e38ff648a6390e48aff490abed987d3199/id3v2.4.0-frames.txt#L591), and in other formats.

This makes it in line with most other tag libraries/editors, see also [mp3tag](https://docs.mp3tag.de/mapping/#releasetime), [TagLib](https://github.com/taglib/taglib/blob/abbf8808720fb916ccee948ffebb8a266ff65cd9/taglib/mpeg/id3v2/id3v2frame.cpp#L339), [kid3](https://github.com/KDE/kid3/blob/70dbaaa264a65dc85fe4e7ff3551cbd0acb144dd/src/core/tags/frame.cpp#L225), [mutagen](https://github.com/quodlibet/mutagen/blob/2115107ee5d4a1480ecb139723f88ee3b84ed521/mutagen/id3/_frames.py#L690):
`date` -> `TDRC`
`originaldate` -> `TDOR`
`releasedate` -> `TDRL`

It fails the test for [pr-544](https://github.com/Borewit/music-metadata/pull/544), but that's 'correct': if you look at the test file `pr-544-id3v24.mp3`, it has a value in `TDRL` (=`releasedate`), while the test written for it tests the empty `TDRC` (= `date`) frame -> logically it fails. It worked before, because TDRL was erroneously mapped to `date` instead of `releasedate`)

I can do two things:
- I can resubmit the test file with a value in `date` (`TDRC`) instead (then the test will work again)
- I can rewrite that test to check for `releasedate`