### PR TITLE
Add iTunes grouping tag, GRP1.

### DIFF
--- a/lib/id3v2/FrameParser.ts
+++ b/lib/id3v2/FrameParser.ts
@@ -96,6 +96,7 @@ export class FrameParser {
     debug(`Parsing tag type=${type}, encoding=${encoding}, bom=${bom}`);
     switch (type !== 'TXXX' && type[0] === 'T' ? 'T*' : type) {
       case 'T*': // 4.2.1. Text information frames - details
+      case 'GRP1': // iTunes-specific ID3v2 grouping field
       case 'IPLS': // v2.3: Involved people list
       case 'MVIN':
       case 'MVNM':


### PR DESCRIPTION
Extremely minimal support for the iTunes-specific `GRP1` tag to address #570 . There is no mapping, but the tag should appear in `metadata.native`. 