### PR TITLE
Prevent subpath imports, for Angular compatibility

### DIFF
--- a/lib/ParserFactory.ts
+++ b/lib/ParserFactory.ts
@@ -19,7 +19,7 @@ import { DsdiffParser } from './dsdiff/DsdiffParser.js';
 import { MatroskaParser } from './matroska/MatroskaParser.js';
 
 import { IOptions, IAudioMetadata, ParserType } from './type.js';
-import { ITokenizer } from 'strtok3/core';
+import type { ITokenizer } from 'strtok3';
 
 const debug = initDebug('music-metadata:parser:factory');
 

--- a/lib/aiff/AiffParser.ts
+++ b/lib/aiff/AiffParser.ts
@@ -1,6 +1,6 @@
 import * as Token from 'token-types';
 import initDebug from 'debug';
-import * as strtok3 from 'strtok3/core';
+import * as strtok3 from 'strtok3';
 
 import { ID3v2Parser } from '../id3v2/ID3v2Parser.js';
 import { FourCcToken } from '../common/FourCC.js';

--- a/lib/apev2/APEv2Parser.ts
+++ b/lib/apev2/APEv2Parser.ts
@@ -1,5 +1,5 @@
 import initDebug from 'debug';
-import * as strtok3 from 'strtok3/core';
+import * as strtok3 from 'strtok3';
 import { StringType } from 'token-types';
 import { uint8ArrayToString } from 'uint8array-extras';
 

--- a/lib/apev2/APEv2Token.ts
+++ b/lib/apev2/APEv2Token.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 import { FourCcToken } from '../common/FourCC.js';
 

--- a/lib/asf/AsfObject.ts
+++ b/lib/asf/AsfObject.ts
@@ -1,7 +1,7 @@
 // ASF Objects
 
 import * as Token from 'token-types';
-import { IGetToken, ITokenizer } from 'strtok3/core';
+import type { IGetToken, ITokenizer } from 'strtok3';
 
 import * as util from '../common/Util.js';
 import { IPicture, ITag } from '../type.js';

--- a/lib/common/BasicParser.ts
+++ b/lib/common/BasicParser.ts
@@ -1,4 +1,4 @@
-import { ITokenizer } from 'strtok3/core';
+import type { ITokenizer } from 'strtok3';
 
 import { ITokenParser } from '../ParserFactory.js';
 import { IOptions, IPrivateOptions } from '../type.js';

--- a/lib/common/FourCC.ts
+++ b/lib/common/FourCC.ts
@@ -1,4 +1,4 @@
-import { IToken } from 'strtok3/core';
+import { IToken } from 'strtok3';
 import { stringToUint8Array, uint8ArrayToString } from 'uint8array-extras';
 
 import * as util from './Util.js';

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -1,4 +1,4 @@
-import * as strtok3 from 'strtok3/core';
+import * as strtok3 from 'strtok3';
 
 import { ParserFactory } from './ParserFactory.js';
 import { RandomUint8ArrayReader } from './common/RandomUint8ArrayReader.js';
@@ -9,7 +9,7 @@ import { getLyricsHeaderLength } from './lyrics3/Lyrics3.js';
 import type { IAudioMetadata, INativeTagDict, IOptions, IPicture, IPrivateOptions, IRandomReader, ITag } from './type.js';
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 
-export { IFileInfo } from 'strtok3/core';
+export { IFileInfo } from 'strtok3';
 
 export type AnyWebStream<G> = NodeReadableStream<G> | ReadableStream<G>;
 
@@ -25,7 +25,7 @@ export async function parseBlob(blob: Blob, options: IOptions = {}): Promise<IAu
   if (blob instanceof File) {
     fileInfo.path = (blob as File).name;
   }
-  return parseWebStream(blob.stream(), fileInfo, options);
+  return parseWebStream(blob.stream() as any, fileInfo, options);
 }
 
 /**

--- a/lib/dsdiff/DsdiffParser.ts
+++ b/lib/dsdiff/DsdiffParser.ts
@@ -1,6 +1,6 @@
 import * as Token from 'token-types';
 import initDebug from 'debug';
-import * as strtok3 from 'strtok3/core';
+import * as strtok3 from 'strtok3';
 
 import { FourCcToken } from '../common/FourCC.js';
 import { BasicParser } from '../common/BasicParser.js';

--- a/lib/dsdiff/DsdiffToken.ts
+++ b/lib/dsdiff/DsdiffToken.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 import { FourCcToken } from '../common/FourCC.js';
 import { IChunkHeader64 } from '../iff/index.js';

--- a/lib/dsf/DsfChunk.ts
+++ b/lib/dsf/DsfChunk.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 import { FourCcToken } from '../common/FourCC.js';
 

--- a/lib/flac/FlacParser.ts
+++ b/lib/flac/FlacParser.ts
@@ -1,6 +1,6 @@
 import { UINT16_BE, UINT24_BE, Uint8ArrayType } from 'token-types';
 import initDebug from 'debug';
-import { ITokenizer, IGetToken } from 'strtok3/core';
+import type { ITokenizer, IGetToken } from 'strtok3';
 
 import * as util from '../common/Util.js';
 import { IVorbisPicture, VorbisPictureToken } from '../ogg/vorbis/Vorbis.js';

--- a/lib/id3v1/ID3v1Parser.ts
+++ b/lib/id3v1/ID3v1Parser.ts
@@ -3,7 +3,7 @@ import { StringType, UINT8 } from 'token-types';
 
 import * as util from '../common/Util.js';
 
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 import { BasicParser } from '../common/BasicParser.js';
 import { APEv2Parser } from '../apev2/APEv2Parser.js';
 import { IRandomReader } from '../type.js';

--- a/lib/id3v2/AbstractID3Parser.ts
+++ b/lib/id3v2/AbstractID3Parser.ts
@@ -1,4 +1,4 @@
-import { EndOfStreamError, ITokenizer } from 'strtok3/core';
+import { EndOfStreamError, ITokenizer } from 'strtok3';
 import initDebug from 'debug';
 
 import { ID3v2Header } from './ID3v2Token.js';

--- a/lib/id3v2/ID3v2Parser.ts
+++ b/lib/id3v2/ID3v2Parser.ts
@@ -1,4 +1,4 @@
-import { ITokenizer } from 'strtok3/core';
+import type { ITokenizer } from 'strtok3';
 import * as Token from 'token-types';
 
 import * as util from '../common/Util.js';

--- a/lib/id3v2/ID3v2Token.ts
+++ b/lib/id3v2/ID3v2Token.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 import * as util from '../common/Util.js';
 

--- a/lib/iff/index.ts
+++ b/lib/iff/index.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 import { FourCcToken } from '../common/FourCC.js';
 

--- a/lib/matroska/MatroskaParser.ts
+++ b/lib/matroska/MatroskaParser.ts
@@ -1,6 +1,6 @@
 import { Float32_BE, Float64_BE, StringType, UINT8 } from 'token-types';
 import initDebug from 'debug';
-import { ITokenizer } from 'strtok3/core';
+import type { ITokenizer } from 'strtok3';
 
 import { INativeMetadataCollector } from '../common/MetadataCollector.js';
 import { BasicParser } from '../common/BasicParser.js';

--- a/lib/mp4/Atom.ts
+++ b/lib/mp4/Atom.ts
@@ -2,7 +2,7 @@ import initDebug from 'debug';
 import * as AtomToken from './AtomToken.js';
 import { Header } from './AtomToken.js';
 
-import { ITokenizer } from 'strtok3/core';
+import type { ITokenizer } from 'strtok3';
 
 export type AtomDataHandler = (atom: Atom, remaining: number) => Promise<void>;
 

--- a/lib/mp4/AtomToken.ts
+++ b/lib/mp4/AtomToken.ts
@@ -3,7 +3,7 @@ import initDebug from 'debug';
 
 import { FourCcToken } from '../common/FourCC.js';
 
-import { IToken, IGetToken } from 'strtok3/core';
+import type { IToken, IGetToken } from 'strtok3';
 
 const debug = initDebug('music-metadata:parser:MP4:atom');
 

--- a/lib/mpeg/ExtendedLameHeader.ts
+++ b/lib/mpeg/ExtendedLameHeader.ts
@@ -2,7 +2,7 @@
  * Extended Lame Header
  */
 
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 import * as Token from 'token-types';
 
 import * as common from '../common/Util.js';

--- a/lib/mpeg/MpegParser.ts
+++ b/lib/mpeg/MpegParser.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { EndOfStreamError } from 'strtok3/core';
+import { EndOfStreamError } from 'strtok3';
 import initDebug from 'debug';
 
 import * as common from '../common/Util.js';

--- a/lib/mpeg/ReplayGainDataFormat.ts
+++ b/lib/mpeg/ReplayGainDataFormat.ts
@@ -1,4 +1,4 @@
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 import * as common from '../common/Util.js';
 
 export interface IReplayGain {

--- a/lib/mpeg/XingTag.ts
+++ b/lib/mpeg/XingTag.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken, ITokenizer } from 'strtok3/core';
+import type { IGetToken, ITokenizer } from 'strtok3';
 
 import * as util from '../common/Util.js';
 import { ExtendedLameHeader, IExtendedLameHeader } from './ExtendedLameHeader.js';

--- a/lib/musepack/sv7/BitReader.ts
+++ b/lib/musepack/sv7/BitReader.ts
@@ -1,4 +1,4 @@
-import { ITokenizer } from 'strtok3/core';
+import type { ITokenizer } from 'strtok3';
 import * as Token from 'token-types';
 
 export class BitReader {

--- a/lib/musepack/sv7/StreamVersion7.ts
+++ b/lib/musepack/sv7/StreamVersion7.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 import * as util from '../../common/Util.js';
 

--- a/lib/musepack/sv8/StreamVersion8.ts
+++ b/lib/musepack/sv8/StreamVersion8.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { ITokenizer, IGetToken } from 'strtok3/core';
+import { ITokenizer, IGetToken } from 'strtok3';
 import initDebug from 'debug';
 
 import * as util from '../../common/Util.js';

--- a/lib/ogg/OggParser.ts
+++ b/lib/ogg/OggParser.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken, EndOfStreamError } from 'strtok3/core';
+import { IGetToken, EndOfStreamError } from 'strtok3';
 import initDebug from 'debug';
 
 import * as util from '../common/Util.js';

--- a/lib/ogg/opus/Opus.ts
+++ b/lib/ogg/opus/Opus.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 /**
  * Opus ID Header interface

--- a/lib/ogg/opus/OpusParser.ts
+++ b/lib/ogg/opus/OpusParser.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import {ITokenizer} from 'strtok3/core';
+import {ITokenizer} from 'strtok3';
 
 import {IPageHeader} from '../Ogg.js';
 import {VorbisParser} from '../vorbis/VorbisParser.js';

--- a/lib/ogg/speex/Speex.ts
+++ b/lib/ogg/speex/Speex.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 import * as util from '../../common/Util.js';
 

--- a/lib/ogg/speex/SpeexParser.ts
+++ b/lib/ogg/speex/SpeexParser.ts
@@ -1,4 +1,4 @@
-import { ITokenizer } from 'strtok3/core';
+import { ITokenizer } from 'strtok3';
 import initDebug from 'debug';
 
 import { IPageHeader } from '../Ogg.js';

--- a/lib/ogg/theora/Theora.ts
+++ b/lib/ogg/theora/Theora.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 /**
  * 6.2 Identification Header

--- a/lib/ogg/theora/TheoraParser.ts
+++ b/lib/ogg/theora/TheoraParser.ts
@@ -1,4 +1,4 @@
-import { ITokenizer } from 'strtok3/core';
+import { ITokenizer } from 'strtok3';
 import initDebug from 'debug';
 
 import * as Ogg from '../Ogg.js';

--- a/lib/ogg/vorbis/Vorbis.ts
+++ b/lib/ogg/vorbis/Vorbis.ts
@@ -3,7 +3,7 @@ import * as Token from 'token-types';
 import { AttachedPictureType } from '../../id3v2/ID3v2Token.js';
 
 import { IPicture } from '../../type.js';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 /**
  * Interface to parsed result of METADATA_BLOCK_PICTURE

--- a/lib/riff/RiffChunk.ts
+++ b/lib/riff/RiffChunk.ts
@@ -1,5 +1,5 @@
 import * as Token from 'token-types';
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 import { IChunkHeader } from '../iff/index.js';
 
 export { IChunkHeader } from '../iff/index.js';

--- a/lib/wav/BwfChunk.ts
+++ b/lib/wav/BwfChunk.ts
@@ -1,4 +1,4 @@
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 import * as Token from 'token-types';
 import { stripNulls } from '../common/Util.js';
 

--- a/lib/wav/WaveChunk.ts
+++ b/lib/wav/WaveChunk.ts
@@ -1,4 +1,4 @@
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 import { IChunkHeader } from '../iff/index.js';
 import * as Token from 'token-types';
 

--- a/lib/wav/WaveParser.ts
+++ b/lib/wav/WaveParser.ts
@@ -1,4 +1,4 @@
-import * as strtok3 from 'strtok3/core';
+import * as strtok3 from 'strtok3';
 import * as Token from 'token-types';
 import initDebug from 'debug';
 

--- a/lib/wavpack/WavPackToken.ts
+++ b/lib/wavpack/WavPackToken.ts
@@ -2,7 +2,7 @@ import * as Token from 'token-types';
 
 import { FourCcToken } from '../common/FourCC.js';
 
-import { IGetToken } from 'strtok3/core';
+import type { IGetToken } from 'strtok3';
 
 /**
  * WavPack Block Header


### PR DESCRIPTION
Prevent [subpath exports](https://nodejs.org/api/packages.html#subpath-exports).