### PR TITLE
Remove remaining Node.js Buffer dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,10 +48,14 @@
           },
           "Symbol": {
             "message": "Avoid using the `Symbol` type. Did you mean `symbol`?"
+          },
+          "Buffer": {
+            "message": "Do not use Node.js specific Buffer type, use Uint8Array"
           }
         }
       }
     ],
+
     "@typescript-eslint/consistent-type-assertions": "error",
     "@typescript-eslint/dot-notation": "error",
     "@typescript-eslint/indent": [
@@ -176,11 +180,11 @@
     "no-new-wrappers": "error",
     "no-redeclare": "error",
     "no-return-await": "error",
-    "no-restricted-syntax": [
+    "no-restricted-globals": ["error", "Buffer"],
+    "no-restricted-imports": [
       "error",
       {
-        "selector": "CallExpression[callee.object.name='Buffer'][callee.property.name='from']",
-        "message": "Use of Buffer.from is forbidden."
+        "paths": ["node:buffer"]
       }
     ],
     "no-sequences": "error",

--- a/lib/common/RandomFileReader.ts
+++ b/lib/common/RandomFileReader.ts
@@ -12,13 +12,13 @@ export class RandomFileReader implements IRandomReader {
 
   /**
    * Read from a given position of an abstracted file or buffer.
-   * @param buffer {Buffer} is the buffer that the data will be written to.
+   * @param buffer {Uint8Array} is the buffer that the data will be written to.
    * @param offset {number} is the offset in the buffer to start writing at.
    * @param length {number}is an integer specifying the number of bytes to read.
    * @param position {number} is an argument specifying where to begin reading from in the file.
    * @return {Promise<number>} bytes read
    */
-  public async randomRead(buffer: Buffer, offset: number, length: number, position: number): Promise<number> {
+  public async randomRead(buffer: Uint8Array, offset: number, length: number, position: number): Promise<number> {
     const result = await this.fileHandle.read(buffer, offset, length, position);
     return result.bytesRead;
   }

--- a/lib/dsf/DsfChunk.ts
+++ b/lib/dsf/DsfChunk.ts
@@ -123,7 +123,7 @@ export interface IFormatChunk {
 export const FormatChunk: IGetToken<IFormatChunk> = {
   len: 40,
 
-  get: (buf: Buffer, off: number): IFormatChunk => {
+  get: (buf: Uint8Array, off: number): IFormatChunk => {
     return {
       formatVersion: Token.INT32_LE.get(buf, off),
       formatID: Token.INT32_LE.get(buf, off + 4),

--- a/lib/flac/FlacParser.ts
+++ b/lib/flac/FlacParser.ts
@@ -191,7 +191,7 @@ class Metadata {
   public static BlockHeader: IGetToken<IBlockHeader> = {
     len: 4,
 
-    get: (buf: Buffer, off: number): IBlockHeader => {
+    get: (buf: Uint8Array, off: number): IBlockHeader => {
       return {
         lastBlock: util.getBit(buf, off, 7),
         type: util.getBitAllignedNumber(buf, off, 1, 7),
@@ -207,7 +207,7 @@ class Metadata {
   public static BlockStreamInfo: IGetToken<IBlockStreamInfo> = {
     len: 34,
 
-    get: (buf: Buffer, off: number): IBlockStreamInfo => {
+    get: (buf: Uint8Array, off: number): IBlockStreamInfo => {
       return {
         // The minimum block size (in samples) used in the stream.
         minimumBlockSize: UINT16_BE.get(buf, off),

--- a/lib/id3v1/ID3v1Parser.ts
+++ b/lib/id3v1/ID3v1Parser.ts
@@ -155,9 +155,9 @@ export class ID3v1Parser extends BasicParser {
 
 export async function hasID3v1Header(reader: IRandomReader): Promise<boolean> {
   if (reader.fileSize >= 128) {
-    const tag = Buffer.alloc(3);
+    const tag = new Uint8Array(3);
     await reader.randomRead(tag, 0, tag.length, reader.fileSize - 128);
-    return tag.toString('latin1') === 'TAG';
+    return new TextDecoder('latin1').decode(tag) === 'TAG';
   }
   return false;
 }

--- a/lib/id3v2/ID3v2Token.ts
+++ b/lib/id3v2/ID3v2Token.ts
@@ -87,7 +87,7 @@ export interface IID3v2header {
 export const ID3v2Header: IGetToken<IID3v2header> = {
   len: 10,
 
-  get: (buf: Buffer, off): IID3v2header => {
+  get: (buf: Uint8Array, off): IID3v2header => {
     return {
       // ID3v2/file identifier   "ID3"
       fileIdentifier: new Token.StringType(3, 'ascii').get(buf, off),

--- a/lib/lyrics3/Lyrics3.ts
+++ b/lib/lyrics3/Lyrics3.ts
@@ -4,12 +4,12 @@ export const endTag2 = 'LYRICS200';
 
 export async function getLyricsHeaderLength(reader: IRandomReader): Promise<number> {
   if (reader.fileSize >= 143) {
-    const buf = Buffer.alloc(15);
+    const buf = new Uint8Array(15);
     await reader.randomRead(buf, 0, buf.length, reader.fileSize - 143);
-    const txt = buf.toString('latin1');
-    const tag = txt.substr(6);
+    const txt = new TextDecoder('latin1').decode(buf);
+    const tag = txt.slice(6);
     if (tag === endTag2) {
-      return parseInt(txt.substr(0, 6), 10) + 15;
+      return parseInt(txt.slice(0, 6), 10) + 15;
     }
   }
   return 0;

--- a/lib/matroska/types.ts
+++ b/lib/matroska/types.ts
@@ -12,12 +12,12 @@ export interface IElementType<T> {
   readonly multiple?: boolean;
 }
 
-export interface IContainerType { [id: number]: IElementType<string | number | boolean | Buffer>; }
+export interface IContainerType { [id: number]: IElementType<string | number | boolean | Uint8Array>; }
 
-export interface ITree { [name: string]: string | number | boolean | Buffer | ITree | ITree[]; }
+export interface ITree { [name: string]: string | number | boolean | Uint8Array | ITree | ITree[]; }
 
 export interface ISeekHead {
-  id?: Buffer;
+  id?: Uint8Array;
   position?: number;
 }
 
@@ -26,7 +26,7 @@ export interface IMetaSeekInformation {
 }
 
 export interface ISegmentInformation {
-  uid?: Buffer;
+  uid?: Uint8Array;
   timecodeScale?: number;
   duration?: number;
   dateUTC?: number;
@@ -36,7 +36,7 @@ export interface ISegmentInformation {
 }
 
 export interface ITrackEntry {
-  uid?: Buffer;
+  uid?: Uint8Array;
   trackNumber?: number;
   trackType?: TrackType;
   audio?: ITrackAudio;
@@ -49,7 +49,7 @@ export interface ITrackEntry {
   name?: string;
   language?: string;
   codecID?: string;
-  codecPrivate?: Buffer;
+  codecPrivate?: Uint8Array;
   codecName?: string;
   codecSettings?: string;
   codecInfoUrl?: string;
@@ -67,7 +67,7 @@ export interface ITrackVideo {
   displayHeight?: number;
   displayUnit?: number;
   aspectRatioType?: number;
-  colourSpace?: Buffer;
+  colourSpace?: Uint8Array;
   gammaValue?: number;
 }
 
@@ -75,7 +75,7 @@ export interface ITrackAudio {
   samplingFrequency?: number;
   outputSamplingFrequency?: number;
   channels?: number;
-  channelPositions?: Buffer;
+  channelPositions?: Uint8Array;
   bitDepth?: number;
 }
 
@@ -102,7 +102,7 @@ export interface ICueReference {
 export interface ISimpleTag {
   name?: string;
   'string'?: string;
-  binary?: Buffer;
+  binary?: Uint8Array;
   language?: string;
   default?: boolean;
 }
@@ -128,9 +128,9 @@ export enum TrackType {
 }
 
 export interface ITarget {
-  trackUID?: Buffer;
-  chapterUID?: Buffer;
-  attachmentUID?: Buffer;
+  trackUID?: Uint8Array;
+  chapterUID?: Uint8Array;
+  attachmentUID?: Uint8Array;
   targetTypeValue?: TargetType;
   targetType?: string;
 }
@@ -152,7 +152,7 @@ export interface IAttachmedFile {
   description?: string;
   name: string;
   mimeType: string;
-  data: Buffer;
+  data: Uint8Array;
   uid: string;
 }
 

--- a/lib/mpeg/MpegParser.ts
+++ b/lib/mpeg/MpegParser.ts
@@ -138,7 +138,7 @@ class MpegFrameHeader {
 
   public mp4ChannelConfig: MPEG4ChannelConfiguration;
 
-  public constructor(buf: Buffer, off: number) {
+  public constructor(buf: Uint8Array, off: number) {
     // B(20,19): MPEG Audio versionIndex ID
     this.versionIndex = common.getBitAllignedNumber(buf, off + 1, 3, 2);
     // C(18,17): Layer description
@@ -184,7 +184,7 @@ class MpegFrameHeader {
     return [null, 4, 1, 1][this.layer];
   }
 
-  private parseMpegHeader(buf: Buffer, off: number): void {
+  private parseMpegHeader(buf: Uint8Array, off: number): void {
     this.container = 'MPEG';
     // E(15,12): Bitrate index
     this.bitrateIndex = common.getBitAllignedNumber(buf, off + 2, 0, 4);
@@ -224,7 +224,7 @@ class MpegFrameHeader {
     }
   }
 
-  private parseAdtsHeader(buf: Buffer, off: number): void {
+  private parseAdtsHeader(buf: Uint8Array, off: number): void {
     debug(`layer=0 => ADTS`);
     this.version = this.versionIndex === 2 ? 4 : 2;
     this.container = 'ADTS/MPEG-' + this.version;
@@ -291,7 +291,7 @@ export class MpegParser extends AbstractID3Parser {
   private calculateEofDuration: boolean = false;
   private samplesPerFrame;
 
-  private buf_frame_header = Buffer.alloc(4);
+  private buf_frame_header = new Uint8Array(4);
 
   /**
    * Number of bytes already parsed since beginning of stream / file
@@ -299,7 +299,7 @@ export class MpegParser extends AbstractID3Parser {
   private mpegOffset: number;
 
   private syncPeek = {
-    buf: Buffer.alloc(maxPeekLen),
+    buf: new Uint8Array(maxPeekLen),
     len: 0
   };
 
@@ -494,7 +494,7 @@ export class MpegParser extends AbstractID3Parser {
   }
 
   private async parseAdts(header: MpegFrameHeader): Promise<boolean> {
-    const buf = Buffer.alloc(3);
+    const buf = new Uint8Array(3);
     await this.tokenizer.readBuffer(buf);
     header.frameLength += common.getBitAllignedNumber(buf, 0, 0, 11);
     this.totalDataLength += header.frameLength;

--- a/lib/mpeg/XingTag.ts
+++ b/lib/mpeg/XingTag.ts
@@ -35,7 +35,7 @@ export interface IXingInfoTag {
    */
   streamSize?: number,
 
-  toc?: Buffer;
+  toc?: Uint8Array;
 
   /**
    * the number of header data bytes (from original file)
@@ -79,7 +79,7 @@ export async function readXingHeader(tokenizer: ITokenizer): Promise<IXingInfoTa
     xingInfoTag.streamSize = await tokenizer.readToken(Token.UINT32_BE);
   }
   if (flags.toc) {
-    xingInfoTag.toc = Buffer.alloc(100);
+    xingInfoTag.toc = new Uint8Array(100);
     await tokenizer.readBuffer(xingInfoTag.toc);
   }
   if (flags.vbrScale) {

--- a/lib/ogg/opus/OpusParser.ts
+++ b/lib/ogg/opus/OpusParser.ts
@@ -25,9 +25,9 @@ export class OpusParser extends VorbisParser {
   /**
    * Parse first Opus Ogg page
    * @param {IPageHeader} header
-   * @param {Buffer} pageData
+   * @param {Uint8Array} pageData
    */
-  protected parseFirstPage(header: IPageHeader, pageData: Buffer) {
+  protected parseFirstPage(header: IPageHeader, pageData: Uint8Array) {
     this.metadata.setFormat('codec', 'Opus');
     // Parse Opus ID Header
     this.idHeader = new Opus.IdHeader(pageData.length).get(pageData, 0);
@@ -37,7 +37,7 @@ export class OpusParser extends VorbisParser {
     this.metadata.setFormat('numberOfChannels', this.idHeader.channelCount);
   }
 
-  protected async parseFullPage(pageData: Buffer): Promise<void> {
+  protected async parseFullPage(pageData: Uint8Array): Promise<void> {
     const magicSignature = new Token.StringType(8, 'ascii').get(pageData, 0);
     switch (magicSignature) {
 

--- a/lib/ogg/speex/Speex.ts
+++ b/lib/ogg/speex/Speex.ts
@@ -42,7 +42,7 @@ export const Header: IGetToken<IHeader> = {
 
   len: 80,
 
-  get: (buf: Buffer, off) => {
+  get: (buf: Uint8Array, off) => {
 
     return {
       speex: new Token.StringType(8, 'ascii').get(buf, off + 0),

--- a/lib/ogg/speex/SpeexParser.ts
+++ b/lib/ogg/speex/SpeexParser.ts
@@ -25,9 +25,9 @@ export class SpeexParser extends VorbisParser {
   /**
    * Parse first Speex Ogg page
    * @param {IPageHeader} header
-   * @param {Buffer} pageData
+   * @param {Uint8Array} pageData
    */
-  protected parseFirstPage(header: IPageHeader, pageData: Buffer) {
+  protected parseFirstPage(header: IPageHeader, pageData: Uint8Array) {
     debug('First Ogg/Speex page');
     const speexHeader = Speex.Header.get(pageData, 0);
     this.metadata.setFormat('codec', `Speex ${speexHeader.version}`);

--- a/lib/ogg/theora/Theora.ts
+++ b/lib/ogg/theora/Theora.ts
@@ -31,7 +31,7 @@ export interface IIdentificationHeader {
 export const IdentificationHeader: IGetToken<IIdentificationHeader> = {
   len: 42,
 
-  get: (buf: Buffer, off): IIdentificationHeader => {
+  get: (buf: Uint8Array, off): IIdentificationHeader => {
     return {
       id: new Token.StringType(7, 'ascii').get(buf, off),
       vmaj: Token.UINT8.get(buf, off + 7),

--- a/lib/ogg/theora/TheoraParser.ts
+++ b/lib/ogg/theora/TheoraParser.ts
@@ -22,7 +22,7 @@ export class TheoraParser implements Ogg.IPageConsumer {
    * @param header Ogg Page Header
    * @param pageData Page data
    */
-  public async parsePage(header: Ogg.IPageHeader, pageData: Buffer): Promise<void> {
+  public async parsePage(header: Ogg.IPageHeader, pageData: Uint8Array): Promise<void> {
     if (header.headerType.firstPage) {
       await this.parseFirstPage(header, pageData);
     }
@@ -41,7 +41,7 @@ export class TheoraParser implements Ogg.IPageConsumer {
    * @param {IPageHeader} header
    * @param {Buffer} pageData
    */
-  protected async parseFirstPage(header: Ogg.IPageHeader, pageData: Buffer): Promise<void> {
+  protected async parseFirstPage(header: Ogg.IPageHeader, pageData: Uint8Array): Promise<void> {
     debug('First Ogg/Theora page');
     this.metadata.setFormat('codec', 'Theora');
     const idHeader = IdentificationHeader.get(pageData, 0);

--- a/lib/wav/WaveChunk.ts
+++ b/lib/wav/WaveChunk.ts
@@ -91,7 +91,7 @@ export class FactChunk implements IGetToken<IFactChunk> {
     this.len = header.chunkSize;
   }
 
-  public get(buf: Buffer, off: number): IFactChunk {
+  public get(buf: Uint8Array, off: number): IFactChunk {
     return {
       dwSampleLength: Token.UINT32_LE.get(buf, off)
     };

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "compile-test": "tsc -p test",
     "compile-doc": "tsc -p doc-gen",
     "compile": "npm run compile-src && npm run compile-test && npm run compile-doc",
-    "eslint": "eslint lib/**/*.ts --ignore-pattern lib/**/*.d.ts example/typescript/**/*.ts test/**/*.ts doc-gen/**/*.ts",
+    "eslint": "npx eslint lib/**/*.ts --ignore-pattern lib/**/*.d.ts example/typescript/**/*.ts test/**/*.ts doc-gen/**/*.ts",
     "lint-md": "remark -u preset-lint-markdown-style-guide .",
     "lint": "npm run lint-md && npm run eslint",
     "test": "mocha",

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -81,9 +81,9 @@ describe('shared utility functionality', () => {
     ];
 
     it('should be able to encode FourCC token', () => {
-      const buffer = Buffer.alloc(4);
+      const buffer = new Uint8Array(4);
       FourCcToken.put(buffer, 0, 'abcd');
-      t.deepEqual(buffer.toString('latin1'), 'abcd');
+      t.deepEqual(new TextDecoder('latin1').decode(buffer), 'abcd');
     });
 
   });


### PR DESCRIPTION
Changes:

1. Remove remaining Buffer usages.
2. Add lint rule to prevent Node.js Buffer usage.

Resolves: #2141 