### PR TITLE
Prevent Matroska parser from crashing when the file size is unknown

### DIFF
--- a/lib/matroska/MatroskaParser.ts
+++ b/lib/matroska/MatroskaParser.ts
@@ -51,7 +51,8 @@ export class MatroskaParser extends BasicParser {
   }
 
   public async parse(): Promise<void> {
-    const matroska = await this.parseContainer(matroskaDtd.elements, this.tokenizer.fileInfo.size, []) as any as IMatroskaDoc;
+    const containerSize = this.tokenizer.fileInfo.size ?? Number.MAX_SAFE_INTEGER;
+    const matroska = await this.parseContainer(matroskaDtd.elements, containerSize, []) as any as IMatroskaDoc;
 
     this.metadata.setFormat('container', `EBML/${matroska.ebml.docType}`);
     if (matroska.segment) {


### PR DESCRIPTION
Resolves: #2145