### PR TITLE
Fix HTML `img` example in README using Base64 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,9 @@ export interface IPicture {
 
 To assign `img` HTML-object you can do something like:
 ```js
-img.src = `data:${picture.format};base64,${picture.data.toString('base64')}`;
+import {uint8ArrayToBase64} from 'uint8array-extras';
+
+img.src = `data:${picture.format};base64,${uint8ArrayToBase64(picture.data)}`;
 ```
 
 ## Frequently Asked Questions


### PR DESCRIPTION
Resolves #2170