### PR TITLE
prototype: allow user to specify which parsers to import

### DIFF
--- a/lib/ParserFactory.ts
+++ b/lib/ParserFactory.ts
@@ -54,7 +54,15 @@ export function parseHttpContentType(contentType: string): { type: string, subty
 
 async function parse(tokenizer: ITokenizer, parserId: ParserType, opts: IOptions = {}): Promise<IAudioMetadata> {
   // Parser found, execute parser
-  const parser = await ParserFactory.loadParser(parserId);
+
+  const parserClass = opts.parsers?.find(parser => parser.parseTypes?.includes(parserId));
+  if (!parserClass) {
+    throw new Error(`Unknown parser type: ${parserId}`);
+  }
+
+  const parser = new parserClass()
+
+  // const parser = ParserFactory.loadParser(parserId);
   const metadata = new MetadataCollector(opts);
   await parser.init(metadata, tokenizer, opts).parse();
   return metadata.toCommonMetadata();
@@ -187,27 +195,27 @@ export class ParserFactory {
     }
   }
 
-  public static async loadParser(moduleName: ParserType): Promise<ITokenParser> {
-    switch (moduleName) {
-      case 'aiff': return new AIFFParser();
-      case 'adts':
-      case 'mpeg':
-        return new MpegParser();
-      case 'apev2': return new APEv2Parser();
-      case 'asf': return new AsfParser();
-      case 'dsf': return new DsfParser();
-      case 'dsdiff': return new DsdiffParser();
-      case 'flac': return new FlacParser();
-      case 'mp4': return new MP4Parser();
-      case 'musepack': return new MusepackParser();
-      case 'ogg': return new OggParser();
-      case 'riff': return new WaveParser();
-      case 'wavpack': return new WavPackParser();
-      case 'matroska': return new MatroskaParser();
-      default:
-        throw new Error(`Unknown parser type: ${moduleName}`);
-    }
-  }
+  // public static loadParser(moduleName: ParserType): ITokenParser {
+  //   switch (moduleName) {
+  //     case 'aiff': return new AIFFParser();
+  //     case 'adts':
+  //     case 'mpeg':
+  //       return new MpegParser();
+  //     case 'apev2': return new APEv2Parser();
+  //     case 'asf': return new AsfParser();
+  //     case 'dsf': return new DsfParser();
+  //     case 'dsdiff': return new DsdiffParser();
+  //     case 'flac': return new FlacParser();
+  //     case 'mp4': return new MP4Parser();
+  //     case 'musepack': return new MusepackParser();
+  //     case 'ogg': return new OggParser();
+  //     case 'riff': return new WaveParser();
+  //     case 'wavpack': return new WavPackParser();
+  //     case 'matroska': return new MatroskaParser();
+  //     default:
+  //       throw new Error(`Unknown parser type: ${moduleName}`);
+  //   }
+  // }
 
   private static getExtension(fname: string): string {
     const i = fname.lastIndexOf('.');

--- a/lib/aiff/AiffParser.ts
+++ b/lib/aiff/AiffParser.ts
@@ -32,6 +32,8 @@ const compressionTypes = {
  */
 export class AIFFParser extends BasicParser {
 
+  static parseTypes = ['aiff']
+
   private isCompressed: boolean;
 
   public async parse(): Promise<void> {

--- a/lib/apev2/APEv2Parser.ts
+++ b/lib/apev2/APEv2Parser.ts
@@ -32,6 +32,8 @@ const preamble = 'APETAGEX';
 
 export class APEv2Parser extends BasicParser {
 
+  static parseTypes = ['apev2'];
+
   public static tryParseApeHeader(metadata: INativeMetadataCollector, tokenizer: strtok3.ITokenizer, options: IOptions) {
     const apeParser = new APEv2Parser();
     apeParser.init(metadata, tokenizer, options);

--- a/lib/asf/AsfParser.ts
+++ b/lib/asf/AsfParser.ts
@@ -20,6 +20,8 @@ const headerType = 'asf';
  */
 export class AsfParser extends BasicParser {
 
+  static parseTypes = ['asf']
+  
   public async parse() {
     const header = await this.tokenizer.readToken<AsfObject.IAsfTopLevelObjectHeader>(AsfObject.TopLevelHeaderObjectToken);
     if (!header.objectId.equals(GUID.HeaderObject)) {

--- a/lib/common/BasicParser.ts
+++ b/lib/common/BasicParser.ts
@@ -5,6 +5,7 @@ import { IOptions, IPrivateOptions } from '../type.js';
 import { INativeMetadataCollector } from './MetadataCollector.js';
 
 export abstract class BasicParser implements ITokenParser {
+  static parseTypes: string[]
 
   protected metadata: INativeMetadataCollector;
   protected tokenizer: ITokenizer;
@@ -27,4 +28,10 @@ export abstract class BasicParser implements ITokenParser {
 
   public abstract parse();
 
+}
+
+export interface BasicParserConstructor {
+  parseTypes: string[]
+
+  new(): BasicParser;
 }

--- a/lib/dsdiff/DsdiffParser.ts
+++ b/lib/dsdiff/DsdiffParser.ts
@@ -17,6 +17,7 @@ const debug = initDebug('music-metadata:parser:aiff');
  * - http://www.sonicstudio.com/pdf/dsd/DSDIFF_1.5_Spec.pdf
  */
 export class DsdiffParser extends BasicParser {
+  static parseTypes = ['dsdiff'];
 
   public async parse(): Promise<void> {
 

--- a/lib/dsf/DsfParser.ts
+++ b/lib/dsf/DsfParser.ts
@@ -12,6 +12,8 @@ const debug = initDebug('music-metadata:parser:DSF');
  */
 export class DsfParser extends AbstractID3Parser {
 
+  static parseTypes = ['dsf']
+
   public async postId3v2Parse(): Promise<void> {
 
     const p0 = this.tokenizer.position; // mark start position, normally 0

--- a/lib/flac/FlacParser.ts
+++ b/lib/flac/FlacParser.ts
@@ -30,6 +30,8 @@ enum BlockType {
 
 export class FlacParser extends AbstractID3Parser {
 
+  static parseTypes = ['flac'];
+
   private vorbisParser: VorbisParser;
 
   private padding: number = 0;

--- a/lib/id3v1/ID3v1Parser.ts
+++ b/lib/id3v1/ID3v1Parser.ts
@@ -106,6 +106,8 @@ class Id3v1StringType extends StringType {
 
 export class ID3v1Parser extends BasicParser {
 
+  static parseTypes = ['not-publicly-exposed'];
+
   private static getGenre(genreIndex: number): string {
     if (genreIndex < Genres.length) {
       return Genres[genreIndex];

--- a/lib/matroska/MatroskaParser.ts
+++ b/lib/matroska/MatroskaParser.ts
@@ -22,6 +22,8 @@ const debug = initDebug('music-metadata:parser:matroska');
  */
 export class MatroskaParser extends BasicParser {
 
+  static parseTypes = ['matroska'];
+
   private padding: number = 0;
 
   private parserMap = new Map<DataType, (e: IHeader) => Promise<any>>();

--- a/lib/mp4/MP4Parser.ts
+++ b/lib/mp4/MP4Parser.ts
@@ -133,6 +133,8 @@ function distinct(value: any, index: number, self: any[]) {
  */
 export class MP4Parser extends BasicParser {
 
+  static parseTypes = ['mp4']
+
   private static read_BE_Integer(array: Uint8Array, signed: boolean): number {
     const integerType = (signed ? 'INT' : 'UINT') + array.length * 8 + (array.length > 1 ? '_BE' : '');
     const token: IGetToken<number | bigint> = Token[integerType];

--- a/lib/mpeg/MpegParser.ts
+++ b/lib/mpeg/MpegParser.ts
@@ -277,6 +277,8 @@ function getVbrCodecProfile(vbrScale: number): string {
 
 export class MpegParser extends AbstractID3Parser {
 
+  static parseTypes = ['adts', 'mpeg'];
+
   private frameCount: number = 0;
   private syncFrameCount: number = -1;
   private countSkipFrameData: number = 0;

--- a/lib/musepack/index.ts
+++ b/lib/musepack/index.ts
@@ -11,6 +11,8 @@ const debug = initDebug('music-metadata:parser:musepack');
 
 class MusepackParser extends AbstractID3Parser {
 
+  static parseTypes = ['musepack'];
+
   public async postId3v2Parse(): Promise<void> {
     const signature = await this.tokenizer.peekToken(new Token.StringType(3, 'latin1'));
     let mpcParser: ITokenParser;

--- a/lib/musepack/sv7/MpcSv7Parser.ts
+++ b/lib/musepack/sv7/MpcSv7Parser.ts
@@ -9,6 +9,8 @@ const debug = initDebug('music-metadata:parser:musepack');
 
 export class MpcSv7Parser extends BasicParser {
 
+  static parseTypes = ['musepack'];
+
   private bitreader: BitReader;
   private audioLength: number = 0;
   private duration: number;

--- a/lib/musepack/sv8/MpcSv8Parser.ts
+++ b/lib/musepack/sv8/MpcSv8Parser.ts
@@ -9,6 +9,8 @@ const debug = initDebug('music-metadata:parser:musepack');
 
 export class MpcSv8Parser extends BasicParser {
 
+  static parseTypes = ['musepack'];
+
   private audioLength: number = 0;
 
   public async parse(): Promise<void> {

--- a/lib/ogg/OggParser.ts
+++ b/lib/ogg/OggParser.ts
@@ -44,6 +44,8 @@ export class SegmentTable implements IGetToken<Ogg.ISegmentTable> {
  */
 export class OggParser extends BasicParser {
 
+  static parseTypes = ['ogg'];
+
   private static Header: IGetToken<Ogg.IPageHeader> = {
     len: 27,
 

--- a/lib/parsers.ts
+++ b/lib/parsers.ts
@@ -1,0 +1,46 @@
+import MusepackParser from './musepack/index.js';
+import { AIFFParser } from './aiff/AiffParser.js';
+import { APEv2Parser } from './apev2/APEv2Parser.js';
+import { AsfParser } from './asf/AsfParser.js';
+import { FlacParser } from './flac/FlacParser.js';
+import { MP4Parser } from './mp4/MP4Parser.js';
+import { MpegParser } from './mpeg/MpegParser.js';
+import { OggParser } from './ogg/OggParser.js';
+import { WaveParser } from './wav/WaveParser.js';
+import { WavPackParser } from './wavpack/WavPackParser.js';
+import { DsfParser } from './dsf/DsfParser.js';
+import { DsdiffParser } from './dsdiff/DsdiffParser.js';
+import { MatroskaParser } from './matroska/MatroskaParser.js';
+import { BasicParserConstructor } from './common/BasicParser.js';
+
+export {
+    AIFFParser,
+    APEv2Parser,
+    AsfParser,
+    FlacParser,
+    MP4Parser,
+    MpegParser,
+    OggParser,
+    WaveParser,
+    WavPackParser,
+    DsfParser,
+    DsdiffParser,
+    MatroskaParser,
+    MusepackParser
+}
+
+export const ALL_PARSERS: BasicParserConstructor[] = [
+    AIFFParser,
+    APEv2Parser,
+    AsfParser,
+    FlacParser,
+    MP4Parser,
+    MpegParser,
+    OggParser,
+    WaveParser,
+    WavPackParser,
+    DsfParser,
+    DsdiffParser,
+    MatroskaParser,
+    MusepackParser
+]

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -2,6 +2,7 @@ import { GenericTagId, TagType } from './common/GenericTagTypes.js';
 import { IFooter } from './apev2/APEv2Token.js';
 import { TrackType } from './matroska/types.js';
 import { LyricsContentType, TimestampFormat } from './id3v2/ID3v2Token.js';
+import { BasicParserConstructor } from './common/BasicParser.js';
 
 export { TrackType } from './matroska/types.js';
 export { LyricsContentType, TimestampFormat } from './id3v2/ID3v2Token.js';
@@ -614,6 +615,11 @@ export interface IOptions {
    * Set observer for async callbacks to common or format.
    */
   observer?: Observer;
+
+  /**
+   * Parsers for specific formats
+   */
+  parsers?: BasicParserConstructor[];
 }
 
 export interface IApeHeader extends IOptions {

--- a/lib/wav/WaveParser.ts
+++ b/lib/wav/WaveParser.ts
@@ -25,6 +25,8 @@ const debug = initDebug('music-metadata:parser:RIFF');
  */
 export class WaveParser extends BasicParser {
 
+  static parseTypes = ['riff'];
+
   private fact: WaveChunk.IFactChunk;
 
   private blockAlign: number;

--- a/lib/wavpack/WavPackParser.ts
+++ b/lib/wavpack/WavPackParser.ts
@@ -15,6 +15,8 @@ const debug = initDebug('music-metadata:parser:WavPack');
  */
 export class WavPackParser extends BasicParser {
 
+  static parseTypes = ['wavpack'];
+
   private audioDataSize: number;
 
   public async parse(): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
       "node": "./lib/index.js",
       "default": "./lib/core.js"
     },
+    "./without-parsers": {
+      "node": "./lib/index-without-parsers.js",
+      "default": "./lib/core-without-parsers.js"
+    },
     "./parsers": "./lib/parsers.js"
   },
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     ".": {
       "node": "./lib/index.js",
       "default": "./lib/core.js"
-    }
+    },
+    "./parsers": "./lib/parsers.js"
   },
   "types": "lib/index.d.ts",
   "files": [

--- a/test/test-file-mp3-custom-parser.ts
+++ b/test/test-file-mp3-custom-parser.ts
@@ -1,0 +1,368 @@
+// This is a copy of test-file-mp3.ts with the only change being that parser is passed explicitly.
+import { assert } from 'chai';
+import path from 'node:path';
+
+import * as mm from '../lib/index-without-parsers.js';
+import { Parsers } from './metadata-parsers.js';
+import { samplePath } from './util.js';
+import { MpegParser } from '../lib/parsers.js';
+
+const parsers = [
+  MpegParser,
+]
+
+describe('Parse MP3 files', () => {
+
+  const mp3SamplePath = path.join(samplePath, 'mp3');
+
+  describe('Test patterns for ISO/MPEG ', () => {
+
+    it.skip('ISO/MPEG 1 Layer 1', async () => {
+
+      // http://mpgedit.org/mpgedit/mpgedit/testdata/mpegdata.html#ISO_m1l1
+      const samples = [
+        {filename: 'fl1.mp1', bitRate: 384, sampleRate: 32000, channels: 2},
+        {filename: 'fl2.mp1', bitRate: 384, sampleRate: 44100, channels: 2},
+        {filename: 'fl3.mp1', bitRate: 384, sampleRate: 48000, channels: 2},
+        {filename: 'fl4.mp1', bitRate: 32, sampleRate: 32000, channels: 1},
+        {filename: 'fl5.mp1', bitRate: 448, sampleRate: 48000, channels: 2},
+        {filename: 'fl6.mp1', bitRate: 384, sampleRate: 44100, channels: 2},
+        {filename: 'fl7.mp1', bitRate: 384, sampleRate: 44100, channels: 2},
+        {filename: 'fl8.mp1', bitRate: 384, sampleRate: 44100, channels: 2}
+      ];
+
+      for (const sample of samples) {
+        const {format} = await mm.parseFile(path.join(mp3SamplePath, 'layer1', sample.filename), {duration: true, parsers});
+        assert.strictEqual(format.container, 'MPEG', 'format.container');
+        assert.strictEqual(format.codec, 'MPEG 1 Layer 1', `'${sample.filename}' format.codec`);
+        assert.strictEqual(format.bitrate, sample.bitRate * 1000, `'${sample.filename}' format.bitrate`);
+        assert.strictEqual(format.sampleRate, sample.sampleRate, `'${sample.filename}' format.sampleRate`);
+        assert.strictEqual(format.numberOfChannels, sample.channels, `'${sample.filename}' format.channels`);
+      }
+
+    });
+
+    it('ISO/MPEG 1 Layer 2', async () => {
+
+      // http://mpgedit.org/mpgedit/mpgedit/testdata/mpegdata.html#ISO_m1l2
+      const samples = [
+        {filename: 'fl10.mp2', bitRate: 192, sampleRate: 32000, channels: 2},
+        {filename: 'fl11.mp2', bitRate: 192, sampleRate: 44100, channels: 2},
+        {filename: 'fl12.mp2', bitRate: 192, sampleRate: 48000, channels: 2},
+        {filename: 'fl13.mp2', bitRate: 32, sampleRate: 32000, channels: 1},
+        {filename: 'fl14.mp2', bitRate: 384, sampleRate: 48000, channels: 2},
+        {filename: 'fl15.mp2', bitRate: 384, sampleRate: 48000, channels: 2},
+        {filename: 'fl16.mp2', bitRate: 256, sampleRate: 48000, channels: 2}
+      ];
+
+      for (const sample of samples) {
+        const {format} = await mm.parseFile(path.join(mp3SamplePath, 'layer2', sample.filename), {duration: true, parsers});
+        assert.strictEqual(format.container, 'MPEG', 'format.container');
+        assert.strictEqual(format.codec, 'MPEG 1 Layer 2', `'${sample.filename}' format.codec`);
+        assert.strictEqual(format.bitrate, sample.bitRate * 1000, `'${sample.filename}' format.bitrate`);
+        assert.strictEqual(format.sampleRate, sample.sampleRate, `'${sample.filename}' format.sampleRate`);
+        assert.strictEqual(format.numberOfChannels, sample.channels, `'${sample.filename}' format.channels`);
+      }
+
+    });
+
+    // http://mpgedit.org/mpgedit/mpgedit/testdata/mpegdata.html#ISO_m1l2
+    it('ISO/MPEG 1 Layer 3', async () => {
+
+      const samples = [
+        {filename: 'compl.mp3', bitRate: 64, sampleRate: 48000, channels: 1},
+        {filename: 'he_32khz.mp3', sampleRate: 32000, channels: 1},
+        {filename: 'he_44khz.mp3', sampleRate: 44100, channels: 1},
+        {filename: 'he_48khz.mp3', sampleRate: 48000, channels: 1},
+        {filename: 'he_mode.mp3', sampleRate: 44100, channels: 1},
+        {filename: 'hecommon.mp3', bitRate: 128, sampleRate: 44100, channels: 2},
+        {filename: 'si.mp3', bitRate: 64, sampleRate: 44100, channels: 1},
+        {filename: 'si.mp3', bitRate: 64, sampleRate: 44100, channels: 1},
+        {filename: 'si_huff.mp3', bitRate: 64, sampleRate: 44100, channels: 1},
+        {filename: 'sin1k0db.mp3', bitRate: 128, sampleRate: 44100, channels: 2}
+      ];
+
+      for (const sample of samples) {
+        const {format} = await mm.parseFile(path.join(mp3SamplePath, 'layer3', sample.filename), {duration: true, parsers});
+        assert.strictEqual(format.container, 'MPEG', 'format.container');
+        assert.strictEqual(format.codec, 'MPEG 1 Layer 3', `'${sample.filename}' format.codec`);
+        if (sample.bitRate) {
+          assert.strictEqual(format.bitrate, sample.bitRate * 1000, `'${sample.filename}' format.bitrate`);
+        }
+        assert.strictEqual(format.sampleRate, sample.sampleRate, `'${sample.filename}' format.sampleRate`);
+        assert.strictEqual(format.numberOfChannels, sample.channels, `'${sample.filename}' format.channels`);
+      }
+
+    });
+
+  });
+
+  it('should handle audio-frame-header-bug', function() {
+
+    this.timeout(15000); // It takes a long time to parse
+
+    const filePath = path.join(samplePath, 'audio-frame-header-bug.mp3');
+
+    return mm.parseFile(filePath, {duration: true, parsers}).then(result => {
+      // FooBar: 3:20.556 (8.844.527 samples); 44100 Hz => 200.5561678004535 seconds
+      // t.strictEqual(result.format.duration, 200.59591666666665); // previous
+      // t.strictEqual(result.format.duration, 200.5561678004535); // FooBar
+
+      // If MPEG Layer II is accepted, it will give back third frame with a different frame length;
+      // therefore it start counting actual parsable frames ending up on ~66.86
+      assert.approximately(result.format.duration, 200.5, 1 / 10);
+    });
+  });
+
+  it('should be able to parse: Sleep Away.mp3', function() {
+
+    this.timeout(15000); // Parsing this file can take a bit longer
+
+    const filePath = path.join(mp3SamplePath, 'Sleep Away.mp3');
+
+    return mm.parseFile(filePath, {duration: true, parsers}).then(metadata => {
+      const {format, common} = metadata;
+
+      assert.deepEqual(format.container, 'MPEG', 'format.container');
+      assert.deepEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
+      assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
+      assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
+
+      assert.strictEqual(common.title, 'Sleep Away');
+      assert.strictEqual(common.artist, 'Bob Acri');
+      assert.deepEqual(common.composer, ['Robert R. Acri']);
+      assert.deepEqual(common.genre, ['Jazz']);
+
+      assert.strictEqual(common.picture.length, 1, 'should contain the cover');
+      const picture = common.picture[0];
+      assert.strictEqual(picture.description, 'thumbnail');
+      assert.strictEqual(picture.format, 'image/jpeg');
+      assert.strictEqual(picture.data.length, 27852);
+    });
+  });
+
+  // https://github.com/Borewit/music-metadata/issues/381
+  it('should be able to handle empty ID3v2 tag', async () => {
+
+    const filePath = path.join(mp3SamplePath, 'issue-381.mp3');
+
+    const {format} = await mm.parseFile(filePath, {parsers});
+
+    assert.deepEqual(format.container, 'MPEG', 'format.container');
+    assert.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.tagTypes');
+  });
+
+  // https://github.com/Borewit/music-metadata/issues/398
+  it('Handle empty picture tag', async () => {
+
+    const filePath = path.join(mp3SamplePath, 'empty-picture-tag.mp3');
+
+    const {format, common, quality} = await mm.parseFile(filePath, {parsers});
+    assert.strictEqual(format.container, 'MPEG', 'format.container');
+    assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
+    assert.strictEqual(common.title, 'Frankie And Johnny', 'common.title');
+    assert.strictEqual(common.artist, 'Sam Cooke', 'common.artist');
+    assert.strictEqual(common.album, 'Greatest Hits', 'common.album,');
+    assert.deepEqual(common.track, {no: 21, of: null}, 'common.track,');
+    assert.deepEqual(common.year, 1998, 'common.year,');
+    assert.isUndefined(common.picture, 'common.picturh');
+    assert.includeDeepMembers(quality.warnings, [{message: 'Empty picture tag found'}], 'quality.warnings includes Empty picture tag found');
+  });
+
+  // https://github.com/Borewit/music-metadata/issues/979
+  it('Handle odd number of octets for 16 bit unicide string', async () => {
+    const filePath = path.join(mp3SamplePath, 'issue-979.mp3'); // TLEN as invalid encode 16 bit unicode string
+
+    const {format, common, quality} = await mm.parseFile(filePath, {duration: true,parsers});
+    assert.strictEqual(format.container, 'MPEG', 'format.container');
+    assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
+
+    assert.strictEqual(common.title, 'Minnie & Me', 'common.title');
+    assert.strictEqual(common.artist, 'Alexander Hacke', 'common.artist');
+    assert.strictEqual(common.album, 'Sanctuary', 'common.album');
+    assert.strictEqual(common.year, 2005, 'common.year');
+
+    assert.includeDeepMembers(quality.warnings, [{
+      message: 'id3v2.3 type=TLEN header has invalid string value: Expected even number of octets for 16-bit unicode string'}],
+    'Warning on invalid TLEN field');
+  });
+
+  // https://github.com/Borewit/music-metadata/issues/430
+  it('Handle preceding ADTS frame with (invalid) frame length of 0 bytes', async () => {
+
+    const filePath = path.join(mp3SamplePath, 'adts-0-frame.mp3');
+
+    const {format, common} = await mm.parseFile(filePath, {duration: true,parsers});
+
+    await mm.parseFile(filePath,{parsers});
+
+    assert.strictEqual(format.container, 'MPEG', 'format.container');
+    assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
+    assert.strictEqual(format.codecProfile, 'V2', 'format.codecProfile');
+    assert.strictEqual(format.tool, 'LAME 3.97b', 'format.tool');
+    assert.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.tagTypes');
+
+    assert.strictEqual(common.title, 'Jan Pillemann Otze', 'common.title');
+    assert.strictEqual(common.artist, 'Mickie Krause', 'common.artist');
+    assert.approximately(format.duration, 217.86, 0.005, 'format.duration');
+  });
+
+  it('Able to handle corrupt LAME header', async () => {
+
+    const filePath = path.join(mp3SamplePath, 'issue-554.mp3');
+
+    const {format, quality} = await mm.parseFile(filePath, {duration: true,parsers});
+
+    assert.strictEqual(format.container, 'MPEG', 'format.container');
+    assert.strictEqual(format.codec, 'MPEG 2 Layer 3', 'format.codec');
+    assert.approximately(format.duration, 817.92, 1 / 200, 'format.duration');
+    assert.strictEqual(format.sampleRate, 22050, 'format.sampleRate');
+
+    assert.includeDeepMembers(quality.warnings, [{message: 'Corrupt LAME header'}], 'quality.warnings includes: \'Corrupt LAME header\'');
+  });
+
+  describe('should handle incomplete MP3 file', () => {
+
+    const filePath = path.join(samplePath, 'incomplete.mp3');
+
+    function checkFormat(format: mm.IFormat) {
+      assert.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.tagTypes');
+      assert.approximately(format.duration, 61.73, 1 / 100, 'format.duration');
+      assert.strictEqual(format.container, 'MPEG', 'format.container');
+      assert.strictEqual(format.codec, 'MPEG 2 Layer 3', 'format.codec');
+      assert.strictEqual(format.lossless, false, 'format.lossless');
+      assert.strictEqual(format.sampleRate, 22050, 'format.sampleRate = 44.1 kHz');
+      assert.strictEqual(format.bitrate, 64000, 'format.bitrate = 128 kbit/sec');
+      assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels 2 (stereo)');
+    }
+
+    it('should decode from a file', async () => {
+      const metadata = await mm.parseFile(filePath,{parsers});
+      checkFormat(metadata.format);
+    });
+  });
+
+  describe('Duration flag behaviour', () => {
+
+    describe('MP3/CBR without Xing header', () => {
+
+      const filePath = path.join(mp3SamplePath, 'Sleep Away.mp3');
+
+      describe('duration=false', () => {
+
+        Parsers
+          .forEach(parser => {
+            it(parser.description, async function(){
+              const metadata = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {duration: false});
+              assert.isUndefined(metadata.format.duration, 'Don\'t expect a duration');
+            });
+          });
+      });
+
+      describe('duration=true', function() {
+
+        this.timeout(15000); // Parsing this file can take a bit longer
+
+        Parsers
+          .forEach(parser => {
+            it(parser.description, async function(){
+              const metadata = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {duration: true});
+              assert.approximately(metadata.format.duration, 200.5, 1 / 10, 'Expect a duration');
+            });
+          });
+      });
+
+    });
+
+  });
+
+  describe('MP3 with APEv2 footer header', () => {
+
+    it('should be able to parse APEv2 header', async () => {
+
+      const filePath = path.join(samplePath, 'issue_56.mp3');
+
+      const metadata = await mm.parseFile(filePath,{parsers});
+      assert.strictEqual(metadata.format.container, 'MPEG');
+      assert.deepEqual(metadata.format.tagTypes, ['ID3v2.3', 'APEv2', 'ID3v1']);
+    });
+
+    it('should be able to parse APEv1 header"', async () => {
+
+      const filePath = path.join(mp3SamplePath, 'issue-362.apev1.mp3');
+
+      const {format, common} = await mm.parseFile(filePath, {duration: true,parsers});
+
+      assert.deepEqual(format.container, 'MPEG', 'format.container');
+
+      assert.deepEqual(format.tagTypes, ['ID3v2.3', 'APEv2', 'ID3v1'], 'format.tagTypes');
+
+      assert.strictEqual(common.title, 'Do They Know It\'s Christmas?', 'common.artist');
+      assert.strictEqual(common.artist, 'Band Aid', 'common.artist');
+      assert.deepEqual(common.artists, ['Band Aid'], 'common.artists');
+      assert.strictEqual(common.album, 'Now That\'s What I Call Xmas', 'common.album');
+      assert.strictEqual(common.year, 2006, 'common.year');
+      assert.deepEqual(common.comment, [{text: 'TunNORM'}, {text:' 0000080E 00000AA9 00002328 000034F4 0002BF65 0002BF4E 000060AC 0000668F 0002BF4E 00033467'}], 'common.comment');
+      assert.deepEqual(common.genre, ['General Holiday'], 'common.genre');
+      assert.deepEqual(common.track.no, 2, 'common.track.no');
+    });
+
+    it('should be able to parse APEv2 header followed by a Lyrics3v2 header', async () => {
+
+      const filePath = path.join(mp3SamplePath, 'APEv2+Lyrics3v2.mp3');
+
+      const metadata = await mm.parseFile(filePath,{parsers});
+      assert.strictEqual(metadata.format.container, 'MPEG');
+      assert.deepEqual(metadata.format.tagTypes, ['ID3v2.3', 'APEv2', 'ID3v1']);
+
+      const ape = mm.orderTags(metadata.native.APEv2);
+      assert.deepEqual(ape.MP3GAIN_MINMAX, ['131,189']);
+      assert.deepEqual(ape.REPLAYGAIN_TRACK_GAIN, ['+0.540000 dB']);
+      assert.deepEqual(ape.REPLAYGAIN_TRACK_PEAK, ['0.497886']);
+      assert.deepEqual(ape.MP3GAIN_UNDO, ['+004,+004,N']);
+    });
+
+  });
+
+  describe('Handle Xing header', () => {
+
+    it('Handle Xing header, without LAME extension', async () => {
+
+      const filePath = path.join(mp3SamplePath, 'Solace.mp3');
+      const {format} = await mm.parseFile(filePath, {duration: true,parsers});
+      assert.strictEqual(format.container, 'MPEG', 'format.container');
+      assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
+      assert.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.tagTypes');
+    });
+
+    describe('Lame extension', () => {
+
+      it('track peak', async () => {
+
+        const filePath = path.join(mp3SamplePath, 'lame-peak.mp3');
+        const {format} = await mm.parseFile(filePath, {duration: true,parsers});
+
+        assert.strictEqual(format.container, 'MPEG', 'format.container');
+        assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
+        assert.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
+        assert.strictEqual(format.tool, 'LAME 3.99r', 'format.tool');
+        assert.approximately(format.trackPeakLevel, 0.21857, 5 / 1000000, 'format.trackPeakLevel');
+        assert.strictEqual(format.trackGain, 6.8, 'format.trackGain');
+        assert.isUndefined(format.albumGain, 'format.albumGain');
+      });
+
+    });
+
+    it('Handle invalid LAME version', async () => {
+      const filePath = path.join(mp3SamplePath, 'issue-828.mp3');
+
+      const {format} = await mm.parseFile(filePath,{parsers});
+
+      assert.strictEqual(format.container, 'MPEG');
+      assert.strictEqual(format.codec, 'MPEG 1 Layer 3');
+      assert.strictEqual(format.tool, 'LAME ZyK! ');
+    });
+
+  });
+
+});


### PR DESCRIPTION
This is very rough prototype of https://github.com/Borewit/music-metadata/issues/894 to see if there is a way forward.

This implements ability for users to import only parsers they need, thus making bundle size smaller.
```ts
import { parserBlob } from 'music-metadata/without-parsers';
import { MpegParser } from 'music-metadata/parsers';

parserBlob(blob, { parsers: [MpegParser] })
```
If user want to use all of the parsers (as with the current version) they can import them all at once.
```ts
import { parserBlob } from 'music-metadata/without-parsers';
import { ALL_PARSERS } from 'music-metadata/parsers';

parserBlob(blob, { parsers: ALL_PARSERS })
```

To support this code changes are quite minimal, however there are few open questions:

1. Should passing parsers be required? That would be breaking change requiring new major version, in this prototype separate entrypoints are added, to prevent existing users from breaking, but I am leaning towards that being overkill since fix is just to import `ALL_PARSERS`.
2. Should we hide parser implementations? This feature technically could allow for user supplied custom parsers or modifying existing ones. To prevent that we could make publicly exposed parsers be black box like this:
```ts
const implSymbol = Symbol('internal');

class MpegParser {
  static parseTypes = ['mpeg'];

  static [implSymbol] = MpegParserImpl;
} 
``` 

@Borewit what do do you think of the idea? If you would allow I would try to submit proper implementation.