### PR TITLE
Enable TypeScript options `strict` & `verbatimModuleSyntax`

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -10,7 +10,8 @@
 		"enabled": true,
 		"rules": {
 			"correctness": {
-				"noConstantCondition": "warn"
+				"noConstantCondition": "warn",
+				"noUnusedImports": "error"
 			},
 			"style": {
 				"noParameterAssign": "off"

--- a/doc-gen/MarkDown.ts
+++ b/doc-gen/MarkDown.ts
@@ -34,7 +34,7 @@ export class Table {
 
   public writeTo(out: fs.WriteStream) {
     const colSizes = this.calcColSizes();
-    Table.writeRow(out, this.header.values, colSizes);
+    Table.writeRow(out, (this.header as Row).values, colSizes);
     out.write(Table.lineToString(colSizes));
     for (const row of this.rows) {
       Table.writeRow(out, row.values, colSizes);
@@ -45,7 +45,7 @@ export class Table {
 
     const maxColSizes: number[] = [];
 
-    for (const row of this.rows.concat([this.header])) {
+    for (const row of this.rows.concat([this.header as Row])) {
       for (let ci = 0; ci < row.values.length; ++ci) {
         if (ci < maxColSizes.length) {
           maxColSizes[ci] = Math.max(maxColSizes[ci], row.values[ci].length);

--- a/lib/aiff/AiffToken.ts
+++ b/lib/aiff/AiffToken.ts
@@ -5,6 +5,20 @@ import type * as iff from '../iff/index.js';
 
 import type { IGetToken } from 'strtok3';
 
+export const compressionTypes = {
+  NONE:	'not compressed	PCM	Apple Computer',
+  sowt:	'PCM (byte swapped)',
+  fl32:	'32-bit floating point IEEE 32-bit float',
+  fl64:	'64-bit floating point IEEE 64-bit float	Apple Computer',
+  alaw:	'ALaw 2:1	8-bit ITU-T G.711 A-law',
+  ulaw:	'µLaw 2:1	8-bit ITU-T G.711 µ-law	Apple Computer',
+  ULAW:	'CCITT G.711 u-law 8-bit ITU-T G.711 µ-law',
+  ALAW:	'CCITT G.711 A-law 8-bit ITU-T G.711 A-law',
+  FL32:	'Float 32	IEEE 32-bit float '
+};
+
+export type CompressionTypeCode = keyof typeof compressionTypes;
+
 /**
  * The Common Chunk.
  * Describes fundamental parameters of the waveform data such as sample rate, bit resolution, and how many channels of
@@ -15,7 +29,7 @@ export interface ICommon {
   numSampleFrames: number,
   sampleSize: number,
   sampleRate: number,
-  compressionType?: string,
+  compressionType?: CompressionTypeCode,
   compressionName?: string
 }
 
@@ -43,7 +57,7 @@ export class Common implements IGetToken<ICommon> {
     };
 
     if (this.isAifc) {
-      res.compressionType = FourCcToken.get(buf, off + 18);
+      res.compressionType = FourCcToken.get(buf, off + 18) as CompressionTypeCode;
       if (this.len > 22) {
         const strLen = Token.UINT8.get(buf, off + 22);
         if (strLen > 0) {

--- a/lib/apev2/APEv2Parser.ts
+++ b/lib/apev2/APEv2Parser.ts
@@ -54,7 +54,7 @@ export class APEv2Parser extends BasicParser {
    * @param reader
    * @param offset
    */
-  public static async findApeFooterOffset(reader: IRandomReader, offset: number): Promise<IApeHeader> {
+  public static async findApeFooterOffset(reader: IRandomReader, offset: number): Promise<IApeHeader | undefined> {
     // Search for APE footer header at the end of the file
     const apeBuf = new Uint8Array(TagFooter.len);
     await reader.randomRead(apeBuf, 0, TagFooter.len, offset - TagFooter.len);
@@ -199,6 +199,10 @@ export class APEv2Parser extends BasicParser {
     this.metadata.setFormat('sampleRate', header.sampleRate);
     this.metadata.setFormat('numberOfChannels', header.channel);
     this.metadata.setFormat('duration', APEv2Parser.calculateDuration(header));
+
+    if (!this.ape.descriptor) {
+      throw new Error('Missing APE descriptor');
+    }
 
     return {
       forwardBytes: this.ape.descriptor.seekTableBytes + this.ape.descriptor.headerDataBytes +

--- a/lib/apev2/APEv2Token.ts
+++ b/lib/apev2/APEv2Token.ts
@@ -199,10 +199,6 @@ export const TagItemHeader: IGetToken<ITagItemHeader> = {
   }
 };
 
-export const TagField = footer => {
-  return new Token.Uint8ArrayType(footer.size - TagFooter.len);
-};
-
 export interface ITagFlags {
   containsHeader: boolean,
   containsFooter: boolean,
@@ -211,7 +207,7 @@ export interface ITagFlags {
   dataType: DataType
 }
 
-export function parseTagFlags(flags): ITagFlags {
+export function parseTagFlags(flags: number): ITagFlags {
   return {
     containsHeader: isBitSet(flags, 31),
     containsFooter: isBitSet(flags, 30),
@@ -226,6 +222,6 @@ export function parseTagFlags(flags): ITagFlags {
  * @param bit 0 is least significant bit (LSB)
  * @return {boolean} true if bit is 1; otherwise false
  */
-export function isBitSet(num, bit): boolean {
+export function isBitSet(num: number, bit: number): boolean {
   return (num & 1 << bit) !== 0;
 }

--- a/lib/asf/AsfObject.ts
+++ b/lib/asf/AsfObject.ts
@@ -266,7 +266,7 @@ export interface IStreamPropertiesObject {
   /**
    * Stream Type
    */
-  streamType: string,
+  streamType: string | undefined,
 
   /**
    * Error Correction Type
@@ -485,7 +485,7 @@ export interface IExtendedStreamPropertiesObject {
   streamNameCount: number,
   payloadExtensionSystems: number,
   streamNames: IStreamName[],
-  streamPropertiesObject: number
+  streamPropertiesObject: number | null
 }
 
 /**
@@ -583,7 +583,7 @@ export class WmPictureToken implements IGetToken<IWmPicture> {
     return pic.get(buffer, 0);
   }
 
-  constructor(public len) {
+  constructor(public len: number) {
   }
 
   public get(buffer: Uint8Array, offset: number): IWmPicture {

--- a/lib/common/BasicParser.ts
+++ b/lib/common/BasicParser.ts
@@ -6,9 +6,9 @@ import type { INativeMetadataCollector } from './MetadataCollector.js';
 
 export abstract class BasicParser implements ITokenParser {
 
-  protected metadata: INativeMetadataCollector;
-  protected tokenizer: ITokenizer;
-  protected options: IPrivateOptions;
+  protected metadata: INativeMetadataCollector = undefined as unknown as INativeMetadataCollector;
+  protected tokenizer: ITokenizer = undefined as unknown as ITokenizer;
+  protected options: IPrivateOptions = undefined as unknown as IPrivateOptions;
 
   /**
    * Initialize parser with output (metadata), input (tokenizer) & parsing options (options).
@@ -25,6 +25,6 @@ export abstract class BasicParser implements ITokenParser {
     return this;
   }
 
-  public abstract parse();
+  public abstract parse(): Promise<void>;
 
 }

--- a/lib/common/CombinedTagMapper.ts
+++ b/lib/common/CombinedTagMapper.ts
@@ -42,7 +42,7 @@ export class CombinedTagMapper {
    * @param warnings
    * @return Generic tag result (output of this function)
    */
-  public mapTag(tagType: TagType, tag: ITag, warnings: INativeMetadataCollector): IGenericTag {
+  public mapTag(tagType: TagType, tag: ITag, warnings: INativeMetadataCollector): IGenericTag | null {
     const tagMapper = this.tagMappers[tagType];
     if (tagMapper) {
       return this.tagMappers[tagType].mapGenericTag(tag, warnings);

--- a/lib/common/GenericTagMapper.ts
+++ b/lib/common/GenericTagMapper.ts
@@ -20,14 +20,14 @@ export interface IGenericTagMapper {
    * @param warnings  Register warnings
    * @return Generic tag, if native tag could be mapped
    */
-  mapGenericTag(tag: ITag, warnings: INativeMetadataCollector): generic.IGenericTag;
+  mapGenericTag(tag: ITag, warnings: INativeMetadataCollector): generic.IGenericTag | null;
 }
 
 export class CommonTagMapper implements IGenericTagMapper {
 
   public static maxRatingScore = 1;
 
-  public static toIntOrNull(str: string): number {
+  public static toIntOrNull(str: string): number | null {
     const cleaned = Number.parseInt(str, 10);
     return Number.isNaN(cleaned) ? null : cleaned;
   }
@@ -53,7 +53,7 @@ export class CommonTagMapper implements IGenericTagMapper {
    * @param warnings Register warnings
    * @return common name
    */
-  public mapGenericTag(tag: ITag, warnings: IWarningCollector): generic.IGenericTag {
+  public mapGenericTag(tag: ITag, warnings: IWarningCollector): generic.IGenericTag | null {
 
     tag = {id: tag.id, value: tag.value}; // clone object
 

--- a/lib/common/GenericTagTypes.ts
+++ b/lib/common/GenericTagTypes.ts
@@ -1,9 +1,9 @@
-import type { AnyTagValue } from '../type.js';
+import type { AnyTagValue, ICommonTagsResult } from '../type.js';
 
 export type TagType = 'vorbis' | 'ID3v1' | 'ID3v2.2' | 'ID3v2.3' | 'ID3v2.4' | 'APEv2' | 'asf' | 'iTunes' | 'exif' | 'matroska' | 'AIFF';
 
 export interface IGenericTag {
-  id: GenericTagId;
+  id: keyof ICommonTagsResult;
   value: AnyTagValue;
 }
 
@@ -263,7 +263,7 @@ export const commonTags: ITagInfoMap = {
  * @param alias Name of common tag
  * @returns {boolean|*} true if given alias is mapped as a singleton', otherwise false
  */
-export function isSingleton(alias: GenericTagId): boolean {
+export function isSingleton(alias: keyof ICommonTagsResult): boolean {
   return commonTags[alias] && !commonTags[alias].multiple;
 }
 
@@ -271,6 +271,6 @@ export function isSingleton(alias: GenericTagId): boolean {
  * @param alias Common (generic) tag
  * @returns {boolean|*} true if given alias is a singleton or explicitly marked as unique
  */
-export function isUnique(alias: GenericTagId): boolean {
-  return !commonTags[alias].multiple || commonTags[alias].unique;
+export function isUnique(alias: keyof ICommonTagsResult): boolean {
+  return !commonTags[alias].multiple || commonTags[alias].unique || false;
 }

--- a/lib/common/Util.ts
+++ b/lib/common/Util.ts
@@ -10,11 +10,6 @@ export type StringEncoding =
   | 'latin1' // Same as ISO-8859-1 (alias: 'binary')
   | 'hex';
 
-export interface ITextEncoding {
-  encoding: StringEncoding;
-  bom?: boolean;
-}
-
 export function getBit(buf: Uint8Array, off: number, bit: number): boolean {
   return (buf[off] & (1 << bit)) !== 0;
 }
@@ -149,7 +144,7 @@ export function dbToRatio(dB: number): number {
  * Convert replay gain to ratio and Decibel
  * @param value string holding a ratio like '0.034' or '-7.54 dB'
  */
-export function toRatio(value: string): IRatio {
+export function toRatio(value: string): IRatio | undefined {
   const ps = value.split(' ').map(p => p.trim().toLowerCase());
   // @ts-ignore
   if (ps.length >= 1) {

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -12,9 +12,9 @@ import { getLyricsHeaderLength } from './lyrics3/Lyrics3.js';
 
 import type { IAudioMetadata, INativeTagDict, IOptions, IPicture, IPrivateOptions, IRandomReader, ITag } from './type.js';
 
-export { IFileInfo } from 'strtok3';
+export type { IFileInfo } from 'strtok3';
 
-export { IAudioMetadata, IOptions, ITag, INativeTagDict, ICommonTagsResult, IFormat, IPicture, IRatio, IChapter, ILyricsTag, LyricsContentType, TimestampFormat } from './type.js';
+export { type IAudioMetadata, type IOptions, type ITag, type INativeTagDict, type ICommonTagsResult, type IFormat, type IPicture, type IRatio, type IChapter, type ILyricsTag, LyricsContentType, TimestampFormat, IMetadataEventTag, IMetadataEvent } from './type.js';
 
 /**
  * Parse Web API File
@@ -92,7 +92,7 @@ export function orderTags(nativeTags: ITag[]): INativeTagDict {
  * @param rating Normalized rating [0..1] (common.rating[n].rating)
  * @returns Number of stars: 1, 2, 3, 4 or 5 stars
  */
-export function ratingToStars(rating: number): number {
+export function ratingToStars(rating: number | undefined): number {
   return rating === undefined ? 0 : 1 + Math.round(rating * 4);
 }
 

--- a/lib/dsdiff/DsdiffParser.ts
+++ b/lib/dsdiff/DsdiffParser.ts
@@ -74,8 +74,12 @@ export class DsdiffParser extends BasicParser {
       }
 
       case 'DSD':
-        this.metadata.setFormat('numberOfSamples', Number(header.chunkSize * BigInt(8) / BigInt(this.metadata.format.numberOfChannels)));
-        this.metadata.setFormat('duration', this.metadata.format.numberOfSamples / this.metadata.format.sampleRate);
+        if (this.metadata.format.numberOfChannels) {
+          this.metadata.setFormat('numberOfSamples', Number(header.chunkSize * BigInt(8) / BigInt(this.metadata.format.numberOfChannels)));
+        }
+        if (this.metadata.format.numberOfSamples && this.metadata.format.sampleRate) {
+          this.metadata.setFormat('duration', this.metadata.format.numberOfSamples / this.metadata.format.sampleRate);
+        }
         break;
 
       default:

--- a/lib/dsdiff/DsdiffToken.ts
+++ b/lib/dsdiff/DsdiffToken.ts
@@ -3,7 +3,7 @@ import type { IGetToken } from 'strtok3';
 
 import { FourCcToken } from '../common/FourCC.js';
 import type { IChunkHeader64 } from '../iff/index.js';
-export { IChunkHeader64 } from '../iff/index.js';
+export { type IChunkHeader64 } from '../iff/index.js';
 
 /**
  * DSDIFF chunk header

--- a/lib/flac/FlacParser.ts
+++ b/lib/flac/FlacParser.ts
@@ -30,7 +30,7 @@ enum BlockType {
 
 export class FlacParser extends AbstractID3Parser {
 
-  private vorbisParser: VorbisParser;
+  private vorbisParser: VorbisParser | undefined;
 
   private padding = 0;
 
@@ -127,7 +127,7 @@ export class FlacParser extends AbstractID3Parser {
     for (let i = 0; i < commentListLength; i++) {
       tags[i] = decoder.parseUserComment();
     }
-    await Promise.all(tags.map(tag => this.vorbisParser.addTag(tag.key, tag.value)));
+    await Promise.all(tags.map(tag => (this.vorbisParser as VorbisParser).addTag(tag.key, tag.value)));
   }
 
   private async parsePicture(dataLen: number) {
@@ -135,7 +135,7 @@ export class FlacParser extends AbstractID3Parser {
       return this.tokenizer.ignore(dataLen);
     }
       const picture = await this.tokenizer.readToken<IVorbisPicture>(new VorbisPictureToken(dataLen));
-      this.vorbisParser.addTag('METADATA_BLOCK_PICTURE', picture);
+      (this.vorbisParser as VorbisParser).addTag('METADATA_BLOCK_PICTURE', picture);
   }
 }
 

--- a/lib/id3v2/ID3v2Parser.ts
+++ b/lib/id3v2/ID3v2Parser.ts
@@ -26,7 +26,7 @@ interface IFrameFlags {
 
 interface IFrameHeader {
   id: string,
-  length?: number;
+  length: number;
   flags?: IFrameFlags;
 }
 
@@ -86,10 +86,10 @@ export class ID3v2Parser {
         return frameParser.readData(uint8Array, frameHeader.id, includeCovers);
       case 3:
       case 4:
-        if (frameHeader.flags.format.unsynchronisation) {
+        if (frameHeader.flags?.format.unsynchronisation) {
           uint8Array = ID3v2Parser.removeUnsyncBytes(uint8Array);
         }
-        if (frameHeader.flags.format.data_length_indicator) {
+        if (frameHeader.flags?.format.data_length_indicator) {
           uint8Array = uint8Array.slice(4, uint8Array.length);
         }
         return frameParser.readData(uint8Array, frameHeader.id, includeCovers);
@@ -108,12 +108,12 @@ export class ID3v2Parser {
     return tag + (description ? `:${description}` : '');
   }
 
-  private tokenizer: ITokenizer;
-  private id3Header: IID3v2header;
-  private metadata: INativeMetadataCollector;
+  private tokenizer: ITokenizer = undefined as unknown as ITokenizer;
+  private id3Header: IID3v2header = undefined as unknown as IID3v2header;
+  private metadata: INativeMetadataCollector = undefined as unknown as INativeMetadataCollector;
 
-  private headerType: TagType;
-  private options: IOptions;
+  private headerType: TagType= undefined as unknown as TagType;
+  private options: IOptions= undefined as unknown as IOptions;
 
   public async parse(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<void> {
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,8 +11,7 @@ import { getParserIdForExtension, parse } from './ParserFactory.js';
 import type { IAudioMetadata, IOptions } from './type.js';
 import { RandomFileReader } from './common/RandomFileReader.js';
 
-export { IAudioMetadata, IOptions, ITag, INativeTagDict, ICommonTagsResult, IFormat, IPicture, IRatio, IChapter, ILyricsTag, LyricsContentType, TimestampFormat } from './type.js';
-export { parseFromTokenizer, parseBuffer, parseBlob, parseWebStream, selectCover, orderTags, ratingToStars, IFileInfo } from './core.js';
+export * from './core.js';
 
 const debug = initDebug('music-metadata:parser');
 
@@ -40,7 +39,7 @@ export async function parseFile(filePath: string, options: IOptions = {}): Promi
 
   const fileTokenizer = await fromFile(filePath);
 
-  const fileReader = await RandomFileReader.init(filePath, fileTokenizer.fileInfo.size);
+  const fileReader = await RandomFileReader.init(filePath, fileTokenizer.fileInfo.size as number);
   try {
     await scanAppendingHeaders(fileReader, options);
   } finally {

--- a/lib/matroska/types.ts
+++ b/lib/matroska/types.ts
@@ -39,9 +39,9 @@ export interface ISegmentInformation {
 
 export interface ITrackEntry {
   uid?: Uint8Array;
-  trackNumber?: number;
+  trackNumber: number;
   trackType?: TrackType;
-  audio?: ITrackAudio;
+  audio: ITrackAudio;
   video?: ITrackVideo;
   flagEnabled?: boolean;
   flagDefault?: boolean;
@@ -50,7 +50,7 @@ export interface ITrackEntry {
   trackTimecodeScale?: number;
   name?: string;
   language?: string;
-  codecID?: string;
+  codecID: string;
   codecPrivate?: Uint8Array;
   codecName?: string;
   codecSettings?: string;
@@ -129,6 +129,8 @@ export enum TrackType {
   control = 0x20
 }
 
+export type TrackTypeKey = keyof TrackType;
+
 export interface ITarget {
   trackUID?: Uint8Array;
   chapterUID?: Uint8Array;
@@ -159,7 +161,7 @@ export interface IAttachmedFile {
 }
 
 export interface IAttachments {
-  attachedFiles?: IAttachmedFile[];
+  attachedFiles: IAttachmedFile[];
 }
 
 export interface IMatroskaSegment {

--- a/lib/mp4/Atom.ts
+++ b/lib/mp4/Atom.ts
@@ -10,7 +10,7 @@ const debug = initDebug('music-metadata:parser:MP4:Atom');
 
 export class Atom {
 
-  public static async readAtom(tokenizer: ITokenizer, dataHandler: AtomDataHandler, parent: Atom, remaining: number): Promise<Atom> {
+  public static async readAtom(tokenizer: ITokenizer, dataHandler: AtomDataHandler, parent: Atom | null, remaining: number): Promise<Atom> {
 
     // Parse atom header
     const offset = tokenizer.position;
@@ -30,7 +30,7 @@ export class Atom {
   public readonly children: Atom[];
   public readonly atomPath: string;
 
-  public constructor(public readonly header: AtomToken.IAtomHeader, public extended: boolean, public readonly parent: Atom) {
+  public constructor(public readonly header: AtomToken.IAtomHeader, public extended: boolean, public readonly parent: Atom | null) {
     this.children = [];
     this.atomPath = (this.parent ? `${this.parent.atomPath}.` : '') + this.header.name;
   }

--- a/lib/mpeg/ExtendedLameHeader.ts
+++ b/lib/mpeg/ExtendedLameHeader.ts
@@ -18,9 +18,9 @@ export interface IExtendedLameHeader {
   revision: number,
   vbr_method: number,
   lowpass_filter: number;
-  track_peak?: number;
-  track_gain: IReplayGain;
-  album_gain: IReplayGain;
+  track_peak?: number | null;
+  track_gain?: IReplayGain;
+  album_gain?: IReplayGain;
   music_length: number;
   music_crc: number;
   header_crc: number;
@@ -40,7 +40,7 @@ export const ExtendedLameHeader: IGetToken<IExtendedLameHeader> = {
       revision: common.getBitAllignedNumber(buf, off, 0, 4),
       vbr_method: common.getBitAllignedNumber(buf, off, 4, 4),
       lowpass_filter: 100 * Token.UINT8.get(buf, off + 1),
-      track_peak: track_peak === 0 ? undefined : track_peak / 2 ** 23,
+      track_peak: track_peak === 0 ? null : track_peak / 2 ** 23,
       track_gain: ReplayGain.get(buf, 6),
       album_gain: ReplayGain.get(buf, 8),
       music_length: Token.UINT32_BE.get(buf, off + 20),

--- a/lib/mpeg/ReplayGainDataFormat.ts
+++ b/lib/mpeg/ReplayGainDataFormat.ts
@@ -56,7 +56,7 @@ enum ReplayGainOriginator {
  *
  * https://github.com/Borewit/music-metadata/wiki/Replay-Gain-Data-Format
  */
-export const ReplayGain: IGetToken<IReplayGain> = {
+export const ReplayGain: IGetToken<IReplayGain | undefined> = {
   len: 2,
 
   get: (buf, off) => {

--- a/lib/mpeg/XingTag.ts
+++ b/lib/mpeg/XingTag.ts
@@ -28,19 +28,19 @@ export interface IXingInfoTag {
   /**
    * total bit stream frames from Vbr header data
    */
-  numFrames?: number,
+  numFrames: number | null,
 
   /**
    * Actual stream size = file size - header(s) size [bytes]
    */
-  streamSize?: number,
+  streamSize: number | null,
 
   toc?: Uint8Array;
 
   /**
    * the number of header data bytes (from original file)
    */
-  vbrScale?: number;
+  vbrScale: number | null;
 
   lame?: {
     version: string;
@@ -71,7 +71,7 @@ export const XingHeaderFlags: IGetToken<IXingHeaderFlags> = {
 //  */
 export async function readXingHeader(tokenizer: ITokenizer): Promise<IXingInfoTag> {
   const flags = await tokenizer.readToken(XingHeaderFlags);
-  const xingInfoTag: IXingInfoTag = {};
+  const xingInfoTag: IXingInfoTag = {numFrames: null, streamSize: null, vbrScale: null};
   if (flags.frames) {
     xingInfoTag.numFrames = await tokenizer.readToken(Token.UINT32_BE);
   }
@@ -92,8 +92,8 @@ export async function readXingHeader(tokenizer: ITokenizer): Promise<IXingInfoTa
       version: await tokenizer.readToken(new Token.StringType(5, 'ascii'))
     };
     const match = xingInfoTag.lame.version.match(/\d+.\d+/g);
-    if (match) {
-      const majorMinorVersion = xingInfoTag.lame.version.match(/\d+.\d+/g)[0]; // e.g. 3.97
+    if (match !== null) {
+      const majorMinorVersion = match[0]; // e.g. 3.97
       const version = majorMinorVersion.split('.').map(n => Number.parseInt(n, 10));
       if (version[0] >= 3 && version[1] >= 90) {
         xingInfoTag.lame.extended = await tokenizer.readToken(ExtendedLameHeader);

--- a/lib/musepack/sv7/BitReader.ts
+++ b/lib/musepack/sv7/BitReader.ts
@@ -4,7 +4,7 @@ import * as Token from 'token-types';
 export class BitReader {
 
   public pos = 0;
-  private dword: number = undefined;
+  private dword: number | null = null;
 
   public constructor(private tokenizer: ITokenizer) {
   }
@@ -15,7 +15,7 @@ export class BitReader {
    */
   public async read(bits: number): Promise<number> {
 
-    while (this.dword === undefined) {
+    while (this.dword === null) {
       this.dword = await this.tokenizer.readToken(Token.UINT32_LE);
     }
 
@@ -28,7 +28,7 @@ export class BitReader {
     }
       this.pos -= 32;
       if (this.pos === 0) {
-        this.dword = undefined;
+        this.dword = null;
         return out & ((1 << bits) - 1);
       }
         this.dword = await this.tokenizer.readToken(Token.UINT32_LE);
@@ -43,7 +43,7 @@ export class BitReader {
 
     if (this.pos > 0) {
       const remaining =  32 - this.pos;
-      this.dword = undefined;
+      this.dword = null;
       bits -= remaining;
       this.pos = 0;
     }

--- a/lib/musepack/sv7/MpcSv7Parser.ts
+++ b/lib/musepack/sv7/MpcSv7Parser.ts
@@ -9,9 +9,9 @@ const debug = initDebug('music-metadata:parser:musepack');
 
 export class MpcSv7Parser extends BasicParser {
 
-  private bitreader: BitReader;
+  private bitreader: BitReader = null as unknown as BitReader;
   private audioLength = 0;
-  private duration: number;
+  private duration: number | null = null;
 
   public async parse(): Promise<void> {
 
@@ -34,7 +34,7 @@ export class MpcSv7Parser extends BasicParser {
     return APEv2Parser.tryParseApeHeader(this.metadata, this.tokenizer, this.options);
   }
 
-  private async skipAudioData(frameCount): Promise<void> {
+  private async skipAudioData(frameCount: number): Promise<void> {
     while (frameCount-- > 0) {
       const frameLength = await this.bitreader.read(20);
       this.audioLength += 20 + frameLength;
@@ -43,6 +43,8 @@ export class MpcSv7Parser extends BasicParser {
     // last frame
     const lastFrameLength = await this.bitreader.read(11);
     this.audioLength += lastFrameLength;
-    this.metadata.setFormat('bitrate', this.audioLength / this.duration);
+    if (this.duration !== null) {
+      this.metadata.setFormat('bitrate', this.audioLength / this.duration);
+    }
   }
 }

--- a/lib/musepack/sv8/MpcSv8Parser.ts
+++ b/lib/musepack/sv8/MpcSv8Parser.ts
@@ -51,7 +51,9 @@ export class MpcSv8Parser extends BasicParser {
           break;
 
         case 'SE': // Stream End
-          this.metadata.setFormat('bitrate', this.audioLength * 8 / this.metadata.format.duration);
+          if (this.metadata.format.duration) {
+            this.metadata.setFormat('bitrate', this.audioLength * 8 / this.metadata.format.duration);
+          }
           return APEv2Parser.tryParseApeHeader(this.metadata, this.tokenizer, this.options);
 
         default:

--- a/lib/ogg/Ogg.ts
+++ b/lib/ogg/Ogg.ts
@@ -70,7 +70,7 @@ export interface IPageConsumer {
    * Calculate duration of provided header
    * @param header Ogg header
    */
-  calculateDuration(header: IPageHeader);
+  calculateDuration(header: IPageHeader): void;
 
   /**
    * Force to parse pending segments

--- a/lib/ogg/opus/Opus.ts
+++ b/lib/ogg/opus/Opus.ts
@@ -52,7 +52,7 @@ export class IdHeader implements IGetToken<IIdHeader> {
     }
   }
 
-  public get(buf, off): IIdHeader {
+  public get(buf: Uint8Array, off: number): IIdHeader {
     return {
       magicSignature: new Token.StringType(8, 'ascii').get(buf, off + 0),
       version: Token.UINT8.get(buf, off + 8),

--- a/lib/ogg/opus/OpusParser.ts
+++ b/lib/ogg/opus/OpusParser.ts
@@ -15,7 +15,7 @@ import * as Opus from './Opus.js';
  */
 export class OpusParser extends VorbisParser {
 
-  private idHeader: Opus.IIdHeader;
+  private idHeader: Opus.IIdHeader = null as unknown as Opus.IIdHeader;
   private lastPos = -1;
 
   constructor(metadata: INativeMetadataCollector, options: IOptions, private tokenizer: ITokenizer) {

--- a/lib/ogg/vorbis/Vorbis.ts
+++ b/lib/ogg/vorbis/Vorbis.ts
@@ -42,7 +42,7 @@ export class VorbisPictureToken implements IGetToken<IVorbisPicture> {
     return pic.get(buffer, 0);
   }
 
-  constructor(public len) {
+  constructor(public len: number) {
   }
 
   public get(buffer: Uint8Array, offset: number): IVorbisPicture {

--- a/lib/ogg/vorbis/VorbisDecoder.ts
+++ b/lib/ogg/vorbis/VorbisDecoder.ts
@@ -2,7 +2,7 @@ import * as Token from 'token-types';
 
 export class VorbisDecoder {
 
-  constructor(private readonly data: Uint8Array, private offset) {
+  constructor(private readonly data: Uint8Array, private offset: number) {
   }
 
   public readInt32(): number {

--- a/lib/ogg/vorbis/VorbisParser.ts
+++ b/lib/ogg/vorbis/VorbisParser.ts
@@ -95,7 +95,7 @@ export class VorbisParser implements IPageConsumer {
     if (this.metadata.format.sampleRate && header.absoluteGranulePosition >= 0) {
       // Calculate duration
       this.metadata.setFormat('numberOfSamples', header.absoluteGranulePosition);
-      this.metadata.setFormat('duration', this.metadata.format.numberOfSamples / this.metadata.format.sampleRate);
+      this.metadata.setFormat('duration', header.absoluteGranulePosition / this.metadata.format.sampleRate);
     }
   }
 

--- a/lib/ogg/vorbis/VorbisTagMapper.ts
+++ b/lib/ogg/vorbis/VorbisTagMapper.ts
@@ -119,10 +119,10 @@ const vorbisTagMap: INativeTagMap = {
 
 export class VorbisTagMapper extends CommonTagMapper {
 
-  public static toRating(email: string, rating: string, maxScore: number): IRating {
+  public static toRating(email: string | undefined | null, rating: string, maxScore: number): IRating {
 
     return {
-      source: email ? email.toLowerCase() : email,
+      source: email ? email.toLowerCase() : undefined,
       rating: (Number.parseFloat(rating) / maxScore) * CommonTagMapper.maxRatingScore
     };
   }

--- a/lib/riff/RiffChunk.ts
+++ b/lib/riff/RiffChunk.ts
@@ -2,7 +2,7 @@ import * as Token from 'token-types';
 import type { IGetToken } from 'strtok3';
 import type { IChunkHeader } from '../iff/index.js';
 
-export { IChunkHeader } from '../iff/index.js';
+export { type IChunkHeader } from '../iff/index.js';
 
 /**
  * Common RIFF chunk header
@@ -32,7 +32,7 @@ export class ListInfoTagValue implements IGetToken<string> {
     this.len += this.len & 1; // if it is an odd length, round up to even
   }
 
-  public get(buf, off): string {
+  public get(buf: Uint8Array, off: number): string {
     return new Token.StringType(this.tagHeader.chunkSize, 'ascii').get(buf, off);
   }
 }

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "declaration": true
+    "declaration": true,
+    "strict": true
   }
 }
 

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -1,4 +1,4 @@
-import type { GenericTagId, TagType } from './common/GenericTagTypes.js';
+import type { TagType } from './common/GenericTagTypes.js';
 import type { IFooter } from './apev2/APEv2Token.js';
 import type { TrackType } from './matroska/types.js';
 import type { LyricsContentType, TimestampFormat } from './id3v2/ID3v2Token.js';
@@ -45,7 +45,7 @@ export interface IRating {
   /**
    * Rating [0..1]
    */
-  rating: number;
+  rating?: number;
 }
 
 export interface ICommonTagsResult {
@@ -159,6 +159,10 @@ export interface ICommonTagsResult {
    * Engineer(s)
    */
   engineer?: string[];
+  /**
+   * Publisher(s)
+   */
+  publisher?: string[];
   /**
    * Producer(s)
    */
@@ -302,9 +306,14 @@ export interface ICommonTagsResult {
   };
 
   /**
-   * minimum & maximum global gain values across a set of files scanned as an album
+   * minimum & maximum global gain values across a set of file
    */
   replaygain_track_minmax?: number[];
+
+  /**
+   * minimum & maximum global gain values across a set of files scanned as an album
+   */
+  replaygain_album_minmax?: number[];
 
   /**
    * The initial key of the music in the file, e.g. "A Minor".
@@ -335,7 +344,7 @@ export interface ICommonTagsResult {
   /**
    * Movement Index/Total
    */
-  movementIndex: { no?: number, of?: number };
+  movementIndex: { no: number | null, of: number | null };
   /**
    * Podcast Identifier
    */
@@ -438,7 +447,7 @@ export interface IFormat {
   /**
    * List of tags found in parsed audio file
    */
-  readonly tagTypes?: TagType[],
+  readonly tagTypes: TagType[],
 
   /**
    * Duration in seconds
@@ -637,6 +646,25 @@ export interface IPrivateOptions extends IOptions {
   apeHeader?: IApeHeader;
 }
 
+export interface IMetadataEventTag {
+
+  /**
+   * Either `common` if it is a generic tag event, or `format` for format related updates
+   */
+  type: 'common' | 'format';
+
+  /**
+   * Tag id
+   */
+  id: keyof ICommonTagsResult | FormatId;
+
+  /**
+   * Tag value
+   */
+  value: AnyTagValue;
+}
+
+
 /**
  * Event definition send after each change to common/format metadata change to observer.
  */
@@ -645,23 +673,7 @@ export interface IMetadataEvent {
   /**
    * Tag which has been updated.
    */
-  tag: {
-
-    /**
-     * Either 'common' if it a generic tag event, or 'format' for format related updates
-     */
-    type: 'common' | 'format'
-
-    /**
-     * Tag id
-     */
-    id: GenericTagId | FormatId
-
-    /**
-     * Tag value
-     */
-    value: AnyTagValue
-  };
+  tag: IMetadataEventTag;
 
   /**
    * Metadata model including the attached tag

--- a/lib/wavpack/WavPackParser.ts
+++ b/lib/wavpack/WavPackParser.ts
@@ -15,7 +15,7 @@ const debug = initDebug('music-metadata:parser:WavPack');
  */
 export class WavPackParser extends BasicParser {
 
-  private audioDataSize: number;
+  private audioDataSize = 0;
 
   public async parse(): Promise<void> {
 
@@ -63,7 +63,9 @@ export class WavPackParser extends BasicParser {
       }
     }
     while (!this.tokenizer.fileInfo.size || this.tokenizer.fileInfo.size - this.tokenizer.position >= BlockHeaderToken.len);
-    this.metadata.setFormat('bitrate', this.audioDataSize * 8 / this.metadata.format.duration);
+    if (this.metadata.format.duration) {
+      this.metadata.setFormat('bitrate', this.audioDataSize * 8 / this.metadata.format.duration);
+    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@biomejs/biome": "1.8.3",
     "@types/chai": "^4.3.16",
     "@types/chai-as-promised": "^7.1.8",
+    "@types/content-type": "^1.1.8",
     "@types/debug": "^4.1.12",
     "@types/media-typer": "^1.1.3",
     "@types/mocha": "^10.0.7",

--- a/test/test-async.ts
+++ b/test/test-async.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import * as mm from '../lib/index.js';
 import { samplePath } from './util.js';
+import type { IMetadataEventTag } from '../lib/type.js';
 
 describe('Asynchronous observer updates', () => {
 
@@ -10,7 +11,7 @@ describe('Asynchronous observer updates', () => {
 
   it('decode a FLAC audio file', async () => {
 
-    const eventTags = [];
+    const eventTags: IMetadataEventTag[] = [];
 
     await mm.parseFile(flacFilePath, {
       observer: (event => {

--- a/test/test-common.ts
+++ b/test/test-common.ts
@@ -92,10 +92,13 @@ describe('function selectCover()', () => {
       const {common} = await mm.parseFile(filePath);
       expect(common.picture).to.have.lengthOf.above(1, multiCoverFile);
       const cover = mm.selectCover(common.picture);
-      if (cover.type) {
-        assert.equal(cover.type, 'Cover (front)', 'cover.type');
-      } else {
-        assert.equal(cover.data, common.picture[0].data, 'First picture if no type is defined');
+      assert.isDefined(cover, 'Cover');
+      if (cover) {
+        if (cover.type) {
+          assert.equal(cover.type, 'Cover (front)', 'cover.type');
+        } else {
+          assert.equal(cover.data, common.picture[0].data, 'First picture if no type is defined');
+        }
       }
     }
   });

--- a/test/test-file-ogg.ts
+++ b/test/test-file-ogg.ts
@@ -58,10 +58,10 @@ describe('Parse Ogg', function() {
 
       function checkFormat(format) {
         assert.deepEqual(format.tagTypes, ['vorbis'], 'format.tagTypes');
-        assert.strictEqual(format.duration, 2.0, 'format.duration = 2.0 sec');
-        assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
+        assert.strictEqual(format.duration, 2.0, 'format.duration [seconds]');
+        assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate [hz]');
         assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels = 2 (stereo)');
-        assert.strictEqual(format.bitrate, 64000, 'bitrate = 64 kbit/sec');
+        assert.strictEqual(format.bitrate, 64000, 'format.bitrate [bit/sec]');
       }
 
       Parsers.forEach(parser => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["mocha", "node"]
+    "types": ["mocha", "node"],
+    "strict": false
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,6 +395,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/content-type@npm:^1.1.8":
+  version: 1.1.8
+  resolution: "@types/content-type@npm:1.1.8"
+  checksum: 10c0/5115a68f9eeb2139f7598519245a47c7e39cae0965c5ea64067190f934e6d1568d6fec0643b113b54351a9472f8b810958b8040af53b15c82d2b2ca46d9af2be
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.0.0, @types/debug@npm:^4.1.12":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
@@ -2724,6 +2731,7 @@ __metadata:
     "@tokenizer/token": "npm:^0.3.0"
     "@types/chai": "npm:^4.3.16"
     "@types/chai-as-promised": "npm:^7.1.8"
+    "@types/content-type": "npm:^1.1.8"
     "@types/debug": "npm:^4.1.12"
     "@types/media-typer": "npm:^1.1.3"
     "@types/mocha": "npm:^10.0.7"


### PR DESCRIPTION
Enable TypeScript options [`strict`](https://www.typescriptlang.org/docs/handbook/compiler-options.html#strict) & [`verbatimModuleSyntax`](https://www.typescriptlang.org/docs/handbook/compiler-options.html#verbatimModuleSyntax)