### PR TITLE
Implement typed errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,33 @@ readMetadata();
 - [AWS SDK for JavaScript](https://aws.amazon.com/sdk-for-javascript/) - Documentation on using the AWS SDK to interact with S3 and other AWS services.
 - [@tokenizer/s3](https://github.com/Borewit/tokenizer-s3) - Example of `ITokenizer` implementation.
 
+### Handling Parse Errors
+
+`music-metadata` provides a robust and extensible error handling system with custom error classes that inherit from the standard JavaScript `Error`.
+All possible parsing errors are part of a union type `UnionOfParseErrors`, ensuring that every error scenario is accounted for in your code.
+
+#### Union of Parse Errors 
+
+All parsing errors extend from the base class `ParseError` and are included in the `UnionOfParseErrors` type:
+```ts
+export type UnionOfParseErrors =
+  | CouldNotDetermineFileTypeError
+  | UnsupportedFileTypeError
+  | UnexpectedFileContentError
+  | FieldDecodingError
+  | InternalParserError;
+```
+
+#### Error Types
+ 
+- `CouldNotDetermineFileTypeError`: Raised when the file type cannot be determined.
+- `UnsupportedFileTypeError`: Raised when an unsupported file type is encountered.
+- `UnexpectedFileContentError`: Raised when the file content does not match the expected format.
+- `FieldDecodingError`: Raised when a specific field in the file cannot be decoded.
+- `InternalParserError`: Raised for internal parser errors.
+
+### Other functions
+
 #### `orderTags` function
 
 Utility to Converts the native tags to a dictionary index on the tag identifier

--- a/lib/ParseError.ts
+++ b/lib/ParseError.ts
@@ -1,0 +1,52 @@
+export type UnionOfParseErrors =
+  | CouldNotDetermineFileTypeError
+  | UnsupportedFileTypeError
+  | UnexpectedFileContentError
+  | FieldDecodingError
+  | InternalParserError;
+
+export const makeParseError = <Name extends string>(name: Name) => {
+  return class ParseError extends Error {
+    name: Name
+    constructor(message: string) {
+      super(message);
+      this.name = name;
+    }
+  }
+}
+
+// Concrete error class representing a file type determination failure.
+export class CouldNotDetermineFileTypeError extends makeParseError('CouldNotDetermineFileTypeError') {
+}
+
+// Concrete error class representing an unsupported file type.
+export class UnsupportedFileTypeError extends makeParseError('UnsupportedFileTypeError') {
+}
+
+// Concrete error class representing unexpected file content.
+class UnexpectedFileContentError extends makeParseError('UnexpectedFileContentError') {
+  constructor(public readonly fileType: string, message: string) {
+    super(message);
+  }
+
+  // Override toString to include file type information.
+  toString(): string {
+    return `${this.name} (FileType: ${this.fileType}): ${this.message}`;
+  }
+}
+
+// Concrete error class representing a field decoding error.
+export class FieldDecodingError extends makeParseError('FieldDecodingError') {
+}
+
+export class InternalParserError extends makeParseError('InternalParserError') {
+}
+
+// Factory function to create a specific type of UnexpectedFileContentError.
+export const makeUnexpectedFileContentError = <FileType extends string>(fileType: FileType) => {
+  return class extends UnexpectedFileContentError {
+    constructor(message: string) {
+      super(fileType, message);
+    }
+  };
+};

--- a/lib/aiff/AiffParser.ts
+++ b/lib/aiff/AiffParser.ts
@@ -7,8 +7,8 @@ import { FourCcToken } from '../common/FourCC.js';
 import { BasicParser } from '../common/BasicParser.js';
 
 import * as AiffToken from './AiffToken.js';
+import { AiffContentError, type CompressionTypeCode, compressionTypes } from './AiffToken.js';
 import * as iff from '../iff/index.js';
-import { type CompressionTypeCode, compressionTypes } from './AiffToken.js';
 
 const debug = initDebug('music-metadata:parser:aiff');
 
@@ -27,7 +27,7 @@ export class AIFFParser extends BasicParser {
 
     const header = await this.tokenizer.readToken<iff.IChunkHeader>(iff.Header);
     if (header.chunkID !== 'FORM')
-      throw new Error('Invalid Chunk-ID, expected \'FORM\''); // Not AIFF format
+      throw new AiffContentError('Invalid Chunk-ID, expected \'FORM\''); // Not AIFF format
 
     const type = await this.tokenizer.readToken<string>(FourCcToken);
     switch (type) {
@@ -43,7 +43,7 @@ export class AIFFParser extends BasicParser {
         break;
 
       default:
-        throw new Error(`Unsupported AIFF type: ${type}`);
+        throw new AiffContentError(`Unsupported AIFF type: ${type}`);
     }
     this.metadata.setFormat('lossless', !this.isCompressed);
 
@@ -70,7 +70,7 @@ export class AIFFParser extends BasicParser {
 
       case 'COMM': { // The Common Chunk
         if (this.isCompressed === null) {
-          throw new Error('Failed to parse AIFF.COMM chunk when compression type is unknown');
+          throw new AiffContentError('Failed to parse AIFF.COMM chunk when compression type is unknown');
         }
         const common = await this.tokenizer.readToken<AiffToken.ICommon>(new AiffToken.Common(header, this.isCompressed));
         this.metadata.setFormat('bitsPerSample', common.sampleSize);

--- a/lib/aiff/AiffToken.ts
+++ b/lib/aiff/AiffToken.ts
@@ -4,6 +4,7 @@ import { FourCcToken } from '../common/FourCC.js';
 import type * as iff from '../iff/index.js';
 
 import type { IGetToken } from 'strtok3';
+import { makeUnexpectedFileContentError } from '../ParseError.js';
 
 export const compressionTypes = {
   NONE:	'not compressed	PCM	Apple Computer',
@@ -18,6 +19,9 @@ export const compressionTypes = {
 };
 
 export type CompressionTypeCode = keyof typeof compressionTypes;
+
+export class AiffContentError extends makeUnexpectedFileContentError('AIFF'){
+}
 
 /**
  * The Common Chunk.
@@ -39,7 +43,7 @@ export class Common implements IGetToken<ICommon> {
 
   public constructor(header: iff.IChunkHeader, private isAifc: boolean) {
     const minimumChunkSize = isAifc ? 22 : 18;
-    if (header.chunkSize < minimumChunkSize) throw new Error(`COMMON CHUNK size should always be at least ${minimumChunkSize}`);
+    if (header.chunkSize < minimumChunkSize) throw new AiffContentError(`COMMON CHUNK size should always be at least ${minimumChunkSize}`);
     this.len = header.chunkSize;
   }
 
@@ -65,7 +69,7 @@ export class Common implements IGetToken<ICommon> {
           if (23 + strLen + padding === this.len) {
             res.compressionName = new Token.StringType(strLen, 'latin1').get(buf, off + 23);
           } else {
-            throw new Error('Illegal pstring length');
+            throw new AiffContentError('Illegal pstring length');
           }
         } else {
           res.compressionName = undefined;

--- a/lib/asf/AsfObject.ts
+++ b/lib/asf/AsfObject.ts
@@ -8,6 +8,10 @@ import type { AnyTagValue, IPicture, ITag } from '../type.js';
 import GUID from './GUID.js';
 import { getParserForAttr, parseUnicodeAttr } from './AsfUtil.js';
 import { AttachedPictureType } from '../id3v2/ID3v2Token.js';
+import { makeUnexpectedFileContentError } from '../ParseError.js';
+
+export class AsfContentParseError extends makeUnexpectedFileContentError('ASF'){
+}
 
 /**
  * Data Type: Specifies the type of information being stored. The following values are recognized.
@@ -113,7 +117,7 @@ export abstract class State<T> implements IGetToken<T> {
     } else {
       const parseAttr = getParserForAttr(valueType);
       if (!parseAttr) {
-        throw new Error(`unexpected value headerType: ${valueType}`);
+        throw new AsfContentParseError(`unexpected value headerType: ${valueType}`);
       }
       tags.push({id: name, value: parseAttr(data as Uint8Array)});
     }

--- a/lib/asf/AsfParser.ts
+++ b/lib/asf/AsfParser.ts
@@ -4,6 +4,8 @@ import { type ITag, TrackType } from '../type.js';
 import GUID from './GUID.js';
 import * as AsfObject from './AsfObject.js';
 import { BasicParser } from '../common/BasicParser.js';
+import { AsfContentParseError } from './AsfObject.js';
+
 
 const debug = initDebug('music-metadata:parser:ASF');
 const headerType = 'asf';
@@ -23,7 +25,7 @@ export class AsfParser extends BasicParser {
   public async parse() {
     const header = await this.tokenizer.readToken<AsfObject.IAsfTopLevelObjectHeader>(AsfObject.TopLevelHeaderObjectToken);
     if (!header.objectId.equals(GUID.HeaderObject)) {
-      throw new Error(`expected asf header; but was not found; got: ${header.objectId.str}`);
+      throw new AsfContentParseError(`expected asf header; but was not found; got: ${header.objectId.str}`);
     }
     try {
       await this.parseObjectHeader(header.numberOfHeaderObjects);

--- a/lib/common/CombinedTagMapper.ts
+++ b/lib/common/CombinedTagMapper.ts
@@ -12,6 +12,7 @@ import type { ITag } from '../type.js';
 import type { INativeMetadataCollector } from './MetadataCollector.js';
 import { MatroskaTagMapper } from '../matroska/MatroskaTagMapper.js';
 import { AiffTagMapper } from '../aiff/AiffTagMap.js';
+import { InternalParserError } from '../ParseError.js';
 
 export class CombinedTagMapper {
 
@@ -47,7 +48,7 @@ export class CombinedTagMapper {
     if (tagMapper) {
       return this.tagMappers[tagType].mapGenericTag(tag, warnings);
     }
-    throw new Error(`No generic tag mapper defined for tag-format: ${tagType}`);
+    throw new InternalParserError(`No generic tag mapper defined for tag-format: ${tagType}`);
   }
 
   private registerTagMapper(genericTagMapper: IGenericTagMapper) {

--- a/lib/common/FourCC.ts
+++ b/lib/common/FourCC.ts
@@ -2,6 +2,7 @@ import type { IToken } from 'strtok3';
 import { stringToUint8Array, uint8ArrayToString } from 'uint8array-extras';
 
 import * as util from './Util.js';
+import { InternalParserError, FieldDecodingError } from '../ParseError.js';
 
 const validFourCC = /^[\x21-\x7e©][\x20-\x7e\x00()]{3}/;
 
@@ -15,7 +16,7 @@ export const FourCcToken: IToken<string> = {
   get: (buf: Uint8Array, off: number): string => {
     const id = uint8ArrayToString(buf.slice(off, off + FourCcToken.len), 'latin1');
     if (!id.match(validFourCC)) {
-      throw new Error(`FourCC contains invalid characters: ${util.a2hex(id)} "${id}"`);
+      throw new FieldDecodingError(`FourCC contains invalid characters: ${util.a2hex(id)} "${id}"`);
     }
     return id;
   },
@@ -23,7 +24,7 @@ export const FourCcToken: IToken<string> = {
   put: (buffer: Uint8Array, offset: number, id: string) => {
     const str = stringToUint8Array(id);
     if (str.length !== 4)
-      throw new Error('Invalid length');
+      throw new InternalParserError('Invalid length');
     buffer.set(str, offset);
     return offset + 4;
   }

--- a/lib/common/Util.ts
+++ b/lib/common/Util.ts
@@ -1,5 +1,6 @@
 import { StringType } from 'token-types';
 import type { IRatio } from '../type.js';
+import { FieldDecodingError } from '../ParseError.js';
 
 export type StringEncoding =
   'ascii' // Use 'utf-8' or latin1 instead
@@ -45,7 +46,7 @@ export function trimRightNull(x: string): string {
 
 function swapBytes<T extends Uint8Array>(uint8Array: T): T {
   const l = uint8Array.length;
-  if ((l & 1) !== 0) throw new Error('Buffer length must be even');
+  if ((l & 1) !== 0) throw new FieldDecodingError('Buffer length must be even');
   for (let i = 0; i < l; i += 2) {
     const a = uint8Array[i];
     uint8Array[i] = uint8Array[i + 1];
@@ -53,7 +54,6 @@ function swapBytes<T extends Uint8Array>(uint8Array: T): T {
   }
   return uint8Array;
 }
-
 
 /**
  * Decode string
@@ -66,7 +66,7 @@ export function decodeString(uint8Array: Uint8Array, encoding: StringEncoding): 
   }if (encoding === 'utf-16le' && uint8Array[0] === 0xFE && uint8Array[1] === 0xFF) {
     // BOM, indicating big endian decoding
     if ((uint8Array.length & 1) !== 0)
-      throw new Error('Expected even number of octets for 16-bit unicode string');
+      throw new FieldDecodingError('Expected even number of octets for 16-bit unicode string');
     return decodeString(swapBytes(uint8Array), encoding);
   }
   return new StringType(uint8Array.length, encoding).get(uint8Array, 0);

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -16,6 +16,8 @@ export type { IFileInfo } from 'strtok3';
 
 export { type IAudioMetadata, type IOptions, type ITag, type INativeTagDict, type ICommonTagsResult, type IFormat, type IPicture, type IRatio, type IChapter, type ILyricsTag, LyricsContentType, TimestampFormat, IMetadataEventTag, IMetadataEvent } from './type.js';
 
+export type * from './ParseError.js'
+
 /**
  * Parse Web API File
  * Requires Blob to be able to stream using a ReadableStreamBYOBReader, only available since Node.js ≥ 20

--- a/lib/dsf/DsfParser.ts
+++ b/lib/dsf/DsfParser.ts
@@ -3,8 +3,12 @@ import initDebug from 'debug';
 import { AbstractID3Parser } from '../id3v2/AbstractID3Parser.js';
 import { ChunkHeader, DsdChunk, FormatChunk, type IChunkHeader, type IDsdChunk, type IFormatChunk } from './DsfChunk.js';
 import { ID3v2Parser } from "../id3v2/ID3v2Parser.js";
+import { makeUnexpectedFileContentError } from '../ParseError.js';
 
 const debug = initDebug('music-metadata:parser:DSF');
+
+export class DsdContentParseError extends makeUnexpectedFileContentError('DSD'){
+}
 
 /**
  * DSF (dsd stream file) File Parser
@@ -16,7 +20,7 @@ export class DsfParser extends AbstractID3Parser {
 
     const p0 = this.tokenizer.position; // mark start position, normally 0
     const chunkHeader = await this.tokenizer.readToken<IChunkHeader>(ChunkHeader);
-    if (chunkHeader.id !== 'DSD ') throw new Error('Invalid chunk signature');
+    if (chunkHeader.id !== 'DSD ') throw new DsdContentParseError('Invalid chunk signature');
     this.metadata.setFormat('container', 'DSF');
     this.metadata.setFormat('lossless', true);
     const dsdChunk = await this.tokenizer.readToken<IDsdChunk>(DsdChunk);

--- a/lib/ebml/EbmlIterator.ts
+++ b/lib/ebml/EbmlIterator.ts
@@ -5,8 +5,12 @@ import { EndOfStreamError, type ITokenizer } from 'strtok3';
 import { DataType, type IElementType, type IHeader, type ITree, type ValueType } from './types.js';
 
 import * as Token from 'token-types';
+import { makeUnexpectedFileContentError } from '../ParseError.js';
 
 const debug = initDebug('music-metadata:parser:ebml');
+
+export class EbmlContentError extends makeUnexpectedFileContentError('EBML'){
+}
 
 export interface ILinkedElementType extends IElementType {
   id: number;
@@ -150,7 +154,7 @@ export class EbmlIterator {
     // Calculate VINT_WIDTH
     while ((msb & mask) === 0) {
       if (oc > maxLength) {
-        throw new Error('VINT value exceeding maximum size');
+        throw new EbmlContentError('VINT value exceeding maximum size');
       }
       ++oc;
       mask >>= 1;
@@ -181,7 +185,7 @@ export class EbmlIterator {
       case 10:
         return this.tokenizer.readNumber(Float64_BE);
       default:
-        throw new Error(`Invalid IEEE-754 float length: ${e.len}`);
+        throw new EbmlContentError(`Invalid IEEE-754 float length: ${e.len}`);
     }
   }
 

--- a/lib/flac/FlacParser.ts
+++ b/lib/flac/FlacParser.ts
@@ -11,8 +11,12 @@ import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
 import type { IOptions } from '../type.js';
 import type { ITokenParser } from '../ParserFactory.js';
 import { VorbisDecoder } from '../ogg/vorbis/VorbisDecoder.js';
+import { makeUnexpectedFileContentError } from '../ParseError.js';
 
 const debug = initDebug('music-metadata:parser:FLAC');
+
+class FlacContentError extends makeUnexpectedFileContentError('FLAC'){
+}
 
 /**
  * FLAC supports up to 128 kinds of metadata blocks; currently the following are defined:
@@ -50,7 +54,7 @@ export class FlacParser extends AbstractID3Parser {
 
     const fourCC = await this.tokenizer.readToken<string>(FourCcToken);
     if (fourCC.toString() !== 'fLaC') {
-      throw new Error('Invalid FLAC preamble');
+      throw new FlacContentError('Invalid FLAC preamble');
     }
 
     let blockHeader: IBlockHeader;
@@ -100,7 +104,7 @@ export class FlacParser extends AbstractID3Parser {
   private async parseBlockStreamInfo(dataLen: number): Promise<void> {
 
     if (dataLen !== BlockStreamInfo.len)
-      throw new Error('Unexpected block-stream-info length');
+      throw new FlacContentError('Unexpected block-stream-info length');
 
     const streamInfo = await this.tokenizer.readToken<IBlockStreamInfo>(BlockStreamInfo);
     this.metadata.setFormat('container', 'FLAC');

--- a/lib/id3v2/FrameParser.ts
+++ b/lib/id3v2/FrameParser.ts
@@ -7,6 +7,7 @@ import { Genres } from '../id3v1/ID3v1Parser.js';
 
 import type { IWarningCollector } from '../common/MetadataCollector.js';
 import type { IComment, ILyricsTag } from '../type.js';
+import { makeUnexpectedFileContentError } from '../ParseError.js';
 
 const debug = initDebug('music-metadata:id3v2:frame-parser');
 
@@ -204,7 +205,7 @@ export class FrameParser {
               break;
 
             default:
-              throw new Error(`Warning: unexpected major versionIndex: ${this.major}`);
+              throw makeUnexpectedMajorVersionError(this.major);
           }
 
           pic.format = FrameParser.fixPictureMimeType(pic.format);
@@ -451,4 +452,11 @@ export class FrameParser {
     return enc === 'utf-16le' ? 2 : 1;
   }
 
+}
+
+export class Id3v2ContentError extends makeUnexpectedFileContentError('id3v2'){
+}
+
+function makeUnexpectedMajorVersionError(majorVer: number) {
+  throw new Id3v2ContentError(`Unexpected majorVer: ${majorVer}`);
 }

--- a/lib/id3v2/ID3v2Parser.ts
+++ b/lib/id3v2/ID3v2Parser.ts
@@ -3,7 +3,7 @@ import * as Token from 'token-types';
 
 import * as util from '../common/Util.js';
 import type { TagType } from '../common/GenericTagTypes.js';
-import { FrameParser, type ITextTag } from './FrameParser.js';
+import { FrameParser, Id3v2ContentError, type ITextTag } from './FrameParser.js';
 import { ExtendedHeader, ID3v2Header, type ID3v2MajorVersion, type IID3v2header, UINT32SYNCSAFE } from './ID3v2Token.js';
 
 import type { ITag, IOptions, AnyTagValue } from '../type.js';
@@ -58,7 +58,7 @@ export class ID3v2Parser {
       case 4:
         return 10;
       default:
-        throw new Error('header versionIndex is incorrect');
+        throw makeUnexpectedMajorVersionError(majorVer);
     }
   }
 
@@ -94,7 +94,7 @@ export class ID3v2Parser {
         }
         return frameParser.readData(uint8Array, frameHeader.id, includeCovers);
       default:
-        throw new Error(`Unexpected majorVer: ${majorVer}`);
+        throw makeUnexpectedMajorVersionError(majorVer);
     }
   }
 
@@ -124,7 +124,7 @@ export class ID3v2Parser {
     const id3Header = await this.tokenizer.readToken(ID3v2Header);
 
     if (id3Header.fileIdentifier !== 'ID3') {
-      throw new Error('expected ID3-header file-identifier \'ID3\' was not found');
+      throw new Id3v2ContentError('expected ID3-header file-identifier \'ID3\' was not found');
     }
 
     this.id3Header = id3Header;
@@ -225,9 +225,13 @@ export class ID3v2Parser {
         break;
 
       default:
-        throw new Error(`Unexpected majorVer: ${majorVer}`);
+        throw makeUnexpectedMajorVersionError(majorVer);
     }
     return header;
   }
-
 }
+
+function makeUnexpectedMajorVersionError(majorVer: number) {
+  throw new Id3v2ContentError(`Unexpected majorVer: ${majorVer}`);
+}
+

--- a/lib/musepack/MusepackConentError.ts
+++ b/lib/musepack/MusepackConentError.ts
@@ -1,0 +1,4 @@
+import { makeUnexpectedFileContentError } from '../ParseError.js';
+
+export class MusepackContentError extends makeUnexpectedFileContentError('Musepack'){
+}

--- a/lib/musepack/index.ts
+++ b/lib/musepack/index.ts
@@ -6,6 +6,7 @@ import { AbstractID3Parser } from '../id3v2/AbstractID3Parser.js';
 
 import { MpcSv8Parser } from './sv8/MpcSv8Parser.js';
 import { MpcSv7Parser } from './sv7/MpcSv7Parser.js';
+import { MusepackContentError } from './MusepackConentError.js';
 
 const debug = initDebug('music-metadata:parser:musepack');
 
@@ -16,17 +17,17 @@ class MusepackParser extends AbstractID3Parser {
     let mpcParser: ITokenParser;
     switch (signature) {
       case 'MP+': {
-        debug('Musepack stream-version 7');
+        debug('Stream-version 7');
         mpcParser = new MpcSv7Parser();
         break;
       }
       case 'MPC': {
-        debug('Musepack stream-version 8');
+        debug('Stream-version 8');
         mpcParser = new MpcSv8Parser();
         break;
       }
       default: {
-        throw new Error('Invalid Musepack signature prefix');
+        throw new MusepackContentError('Invalid signature prefix');
       }
     }
     mpcParser.init(this.metadata, this.tokenizer, this.options);

--- a/lib/musepack/sv7/MpcSv7Parser.ts
+++ b/lib/musepack/sv7/MpcSv7Parser.ts
@@ -4,6 +4,7 @@ import { BasicParser } from '../../common/BasicParser.js';
 import { APEv2Parser } from '../../apev2/APEv2Parser.js';
 import { BitReader } from './BitReader.js';
 import * as SV7 from './StreamVersion7.js';
+import { MusepackContentError } from '../MusepackConentError.js';
 
 const debug = initDebug('music-metadata:parser:musepack');
 
@@ -17,7 +18,7 @@ export class MpcSv7Parser extends BasicParser {
 
     const header = await this.tokenizer.readToken<SV7.IHeader>(SV7.Header);
 
-    if (header.signature !== 'MP+') throw new Error('Unexpected magic number');
+    if (header.signature !== 'MP+') throw new MusepackContentError('Unexpected magic number');
     debug(`stream-version=${header.streamMajorVersion}.${header.streamMinorVersion}`);
     this.metadata.setFormat('container', 'Musepack, SV7');
     this.metadata.setFormat('sampleRate', header.sampleFrequency);

--- a/lib/musepack/sv8/MpcSv8Parser.ts
+++ b/lib/musepack/sv8/MpcSv8Parser.ts
@@ -4,6 +4,7 @@ import { BasicParser } from '../../common/BasicParser.js';
 import { APEv2Parser } from '../../apev2/APEv2Parser.js';
 import { FourCcToken } from '../../common/FourCC.js';
 import * as SV8 from './StreamVersion8.js';
+import { MusepackContentError } from '../MusepackConentError.js';
 
 const debug = initDebug('music-metadata:parser:musepack');
 
@@ -14,7 +15,7 @@ export class MpcSv8Parser extends BasicParser {
   public async parse(): Promise<void> {
 
     const signature = await this.tokenizer.readToken(FourCcToken);
-    if (signature !== 'MPCK') throw new Error('Invalid Magic number');
+    if (signature !== 'MPCK') throw new MusepackContentError('Invalid Magic number');
     this.metadata.setFormat('container', 'Musepack, SV8');
     return this.parsePacket();
   }
@@ -57,7 +58,7 @@ export class MpcSv8Parser extends BasicParser {
           return APEv2Parser.tryParseApeHeader(this.metadata, this.tokenizer, this.options);
 
         default:
-          throw new Error(`Unexpected header: ${header.key}`);
+          throw new MusepackContentError(`Unexpected header: ${header.key}`);
       }
     } while (true);
   }

--- a/lib/ogg/OggParser.ts
+++ b/lib/ogg/OggParser.ts
@@ -12,6 +12,10 @@ import { SpeexParser } from './speex/SpeexParser.js';
 import { TheoraParser } from './theora/TheoraParser.js';
 
 import type * as Ogg from './Ogg.js';
+import { makeUnexpectedFileContentError } from '../ParseError.js';
+
+export class OggContentError extends makeUnexpectedFileContentError('Ogg'){
+}
 
 const debug = initDebug('music-metadata:parser:ogg');
 
@@ -83,7 +87,7 @@ export class OggParser extends BasicParser {
       do {
         header = await this.tokenizer.readToken<Ogg.IPageHeader>(OggParser.Header);
 
-        if (header.capturePattern !== 'OggS') throw new Error('Invalid Ogg capture pattern');
+        if (header.capturePattern !== 'OggS') throw new OggContentError('Invalid Ogg capture pattern');
         this.metadata.setFormat('container', 'Ogg');
         this.header = header;
 
@@ -115,7 +119,7 @@ export class OggParser extends BasicParser {
               this.pageConsumer = new TheoraParser(this.metadata, this.options, this.tokenizer);
               break;
             default:
-              throw new Error(`gg audio-codec not recognized (id=${id})`);
+              throw new OggContentError(`gg audio-codec not recognized (id=${id})`);
           }
         }
         await this.pageConsumer.parsePage(header, pageData);

--- a/lib/ogg/opus/Opus.ts
+++ b/lib/ogg/opus/Opus.ts
@@ -1,5 +1,6 @@
 import * as Token from 'token-types';
 import type { IGetToken } from 'strtok3';
+import { makeUnexpectedFileContentError } from '../../ParseError.js';
 
 /**
  * Opus ID Header interface
@@ -40,6 +41,9 @@ export interface IIdHeader {
   channelMapping: number
 }
 
+export class OpusContentError extends makeUnexpectedFileContentError('Opus'){
+}
+
 /**
  * Opus ID Header parser
  * Ref: https://wiki.xiph.org/OggOpus#ID_Header
@@ -48,7 +52,7 @@ export class IdHeader implements IGetToken<IIdHeader> {
 
   constructor(public len: number) {
     if (len < 19) {
-      throw new Error("ID-header-page 0 should be at least 19 bytes long");
+      throw new OpusContentError('ID-header-page 0 should be at least 19 bytes long');
     }
   }
 

--- a/lib/ogg/opus/OpusParser.ts
+++ b/lib/ogg/opus/OpusParser.ts
@@ -7,6 +7,7 @@ import type {IOptions} from '../../type.js';
 import type {INativeMetadataCollector} from '../../common/MetadataCollector.js';
 
 import * as Opus from './Opus.js';
+import { OpusContentError } from './Opus.js';
 
 /**
  * Opus parser
@@ -32,7 +33,7 @@ export class OpusParser extends VorbisParser {
     // Parse Opus ID Header
     this.idHeader = new Opus.IdHeader(pageData.length).get(pageData, 0);
     if (this.idHeader.magicSignature !== "OpusHead")
-      throw new Error("Illegal ogg/Opus magic-signature");
+      throw new OpusContentError("Illegal ogg/Opus magic-signature");
     this.metadata.setFormat('sampleRate', this.idHeader.inputSampleRate);
     this.metadata.setFormat('numberOfChannels', this.idHeader.channelCount);
   }

--- a/lib/wav/WaveChunk.ts
+++ b/lib/wav/WaveChunk.ts
@@ -1,6 +1,10 @@
 import type { IGetToken } from 'strtok3';
 import type { IChunkHeader } from '../iff/index.js';
 import * as Token from 'token-types';
+import { makeUnexpectedFileContentError } from '../ParseError.js';
+
+export class WaveContentError extends makeUnexpectedFileContentError('Wave'){
+}
 
 /**
  * Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/dd317599(v=vs.85).aspx
@@ -55,7 +59,7 @@ export class Format implements IGetToken<IWaveFormat> {
 
   public constructor(header: IChunkHeader) {
     if (header.chunkSize < 16)
-      throw new Error('Invalid chunk size');
+      throw new WaveContentError('Invalid chunk size');
     this.len = header.chunkSize;
   }
 
@@ -86,7 +90,7 @@ export class FactChunk implements IGetToken<IFactChunk> {
 
   public constructor(header: IChunkHeader) {
     if (header.chunkSize < 4) {
-      throw new Error('Invalid fact chunk size.');
+      throw new WaveContentError('Invalid fact chunk size.');
     }
     this.len = header.chunkSize;
   }

--- a/lib/wav/WaveParser.ts
+++ b/lib/wav/WaveParser.ts
@@ -10,6 +10,7 @@ import { FourCcToken } from '../common/FourCC.js';
 import { BasicParser } from '../common/BasicParser.js';
 import { BroadcastAudioExtensionChunk, type IBroadcastAudioExtensionChunk } from './BwfChunk.js';
 import type { AnyTagValue } from '../type.js';
+import { WaveContentError } from './WaveChunk.js';
 
 const debug = initDebug('music-metadata:parser:RIFF');
 
@@ -50,7 +51,7 @@ export class WaveParser extends BasicParser {
       case 'WAVE':
         return this.readWaveChunk(chunkSize - FourCcToken.len);
       default:
-        throw new Error(`Unsupported RIFF format: RIFF/${type}`);
+        throw new WaveContentError(`Unsupported RIFF format: RIFF/${type}`);
     }
   }
 
@@ -184,7 +185,7 @@ export class WaveParser extends BasicParser {
     }
 
     if (chunkSize !== 0) {
-      throw new Error(`Illegal remaining size: ${chunkSize}`);
+      throw new WaveContentError(`Illegal remaining size: ${chunkSize}`);
     }
   }
 

--- a/test/test-mime.ts
+++ b/test/test-mime.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 
 import * as mm from '../lib/index.js';
 import { SourceStream, samplePath } from './util.js';
+import { CouldNotDetermineFileTypeError, UnsupportedFileTypeError } from '../lib/ParseError.js';
 
 describe('MIME & extension mapping', () => {
 
@@ -97,6 +98,7 @@ describe('MIME & extension mapping', () => {
         assert.fail('Should throw an Error');
       } catch (err) {
         assert.equal(err.message, 'Failed to determine audio format');
+        assert.instanceOf(err, CouldNotDetermineFileTypeError);
       }
 
     });
@@ -111,6 +113,7 @@ describe('MIME & extension mapping', () => {
         assert.fail('Should throw an Error');
       } catch (err) {
         assert.equal(err.message, 'Guessed MIME-type not supported: image/jpeg');
+        assert.instanceOf(err, UnsupportedFileTypeError);
       }
     });
 


### PR DESCRIPTION
This PR standardizes the error handling in the parsing module by introducing specific error classes, ensuring all thrown errors are of the type `ParseErrorType`. This enhancement improves type safety, clarity, and consistency across the codebase.

### Changes Introduced

The following custom error classes have been introduced to represent specific parsing errors:

- `CouldNotDetermineFileTypeErro`r: Thrown when the parser cannot determine the file type.
- `UnsupportedFileTypeError:` Thrown when an unsupported file type is encountered.
- `UnexpectedFileContentError`: Thrown when the file content does not match the expected format.
- `InternalParserError`: Thrown in case of an internal error during parsing.

### Unified Error Type
All the above error classes are grouped under a new union type, `KindOfParseError`, which provides a common structure for parsing-related

```ts
type KindOfParseError = 
  | CouldNotDetermineFileTypeError
  | UnsupportedFileTypeError
  | UnexpectedFileContentError
  | InternalParserError;
``` 
Each error class shares a common `name` property, which is useful for error identification and handling (`switch`ing). 

  
PR suggestion provided by sponsor @schickling: 
> One thing that would be great as well would be to have improved error paths
Eg typed errors

@schickling can you please review?