### PR TITLE
Add `loadMusicMetadata()` typing for CommonJS (hack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ const { loadMusicMetadata } = require('music-metadata');
 ```
 
 > [!NOTE]
-> The `loadMusicMetadata` function is experimental and is not currently covered by any TypeScript typings.
+> The `loadMusicMetadata` function is experimental.
 
 ## Frequently Asked Questions
 

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -122,3 +122,5 @@ export async function scanAppendingHeaders(randomReader: IRandomReader, options:
 
   options.apeHeader = await APEv2Parser.findApeFooterOffset(randomReader, apeOffset);
 }
+
+export declare function loadMusicMetadata(): Promise<typeof import('music-metadata')>;


### PR DESCRIPTION
Workaround for typing issue as discussed https://github.com/Borewit/music-metadata/issues/1357#issuecomment-2320784650