### PR TITLE
Fix handling extended atom size in MP4

### DIFF
--- a/lib/mp4/MP4Parser.ts
+++ b/lib/mp4/MP4Parser.ts
@@ -246,7 +246,6 @@ export class MP4Parser extends BasicParser {
   }
 
   public async handleAtom(atom: Atom, remaining: number): Promise<void> {
-
     if (atom.parent) {
       switch (atom.parent.header.name) {
         case 'ilst':


### PR DESCRIPTION
Fix bug which can occur when processing an MP4 file, with an atom using an extended header size