### PR TITLE
Fix ID3v2 GEOB parsing

### DIFF
--- a/lib/id3v2/FrameParser.ts
+++ b/lib/id3v2/FrameParser.ts
@@ -313,10 +313,10 @@ export class FrameParser {
         fzero = util.findZero(uint8Array, offset + 1, length, encoding);
         const mimeType = util.decodeString(uint8Array.slice(offset + 1, fzero), defaultEnc);
         offset = fzero + 1;
-        fzero = util.findZero(uint8Array, offset, length - offset, encoding);
+        fzero = util.findZero(uint8Array, offset, length, encoding);
         const filename = util.decodeString(uint8Array.slice(offset, fzero), defaultEnc);
         offset = fzero + 1;
-        fzero = util.findZero(uint8Array, offset, length - offset, encoding);
+        fzero = util.findZero(uint8Array, offset, length, encoding);
         const description = util.decodeString(uint8Array.slice(offset, fzero), defaultEnc);
 
         const geob: IGeneralEncapsulatedObject = {

--- a/lib/id3v2/FrameParser.ts
+++ b/lib/id3v2/FrameParser.ts
@@ -318,12 +318,13 @@ export class FrameParser {
         offset = fzero + 1;
         fzero = util.findZero(uint8Array, offset, length, encoding);
         const description = util.decodeString(uint8Array.slice(offset, fzero), defaultEnc);
+        offset = fzero + 1;
 
         const geob: IGeneralEncapsulatedObject = {
           type: mimeType,
           filename,
           description,
-          data: uint8Array.slice(offset + 1, length)
+          data: uint8Array.slice(offset, length)
         };
         output = geob;
         break;


### PR DESCRIPTION
The ID3v2 frame parser was not parsing correctly GEOB fields:
- It was basically cutting the description too soon if data were too short due to incorrect length expression.
- Description characters were leaking to the data array due to invalid offset computation.

Now fixed.

Related to: #406