### PR TITLE
Fix handling reading AMR audio file from stream

### DIFF
--- a/lib/amr/AmrToken.ts
+++ b/lib/amr/AmrToken.ts
@@ -1,7 +1,7 @@
 import type { IGetToken } from 'strtok3';
 import { getBitAllignedNumber } from '../common/Util.js';
 
-interface IFrameHeader {
+export interface IFrameHeader {
   frameType: number;
 }
 

--- a/test/test-file-amr.ts
+++ b/test/test-file-amr.ts
@@ -9,7 +9,7 @@ describe('Adaptive Multi-Rate (AMR) audio file', () => {
 
   Parsers.forEach(parser => {
 
-    describe('parser.description', () => {
+    describe(parser.description, () => {
 
       it('parse: sample.amr', async function () {
         const {metadata} = await parser.initParser(() => this.skip(), path.join(amrPath, 'sample.amr'), 'audio/amr', {duration: true});


### PR DESCRIPTION
- Properly handle `EndOfStreamError`, in case the length of the stream is unknown (not provided).
- Fix passing correct description in AMR unit test.