### PR TITLE
Set Mocha test timeout global

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,5 +3,6 @@
   "watch-files": ["lib/**/*.ts", "test/**/*.ts"],
   "spec": ["test/*.ts"],
   "loader": ["ts-node/esm"],
-  "extensions": ["ts", "tsx"]
+  "extensions": ["ts", "tsx"],
+  "timeout": 15000
 }

--- a/test/test-file-aac.ts
+++ b/test/test-file-aac.ts
@@ -26,11 +26,10 @@ describe('Parse ADTS/AAC', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function (){
-        this.timeout(10000);
-        const {metadata} = await parser.initParser(() => this.skip(), path.join(aacSamplePath, 'adts-mpeg4.aac'), 'audio/aac', {
+        const {format} = await parser.initParser(() => this.skip(), path.join(aacSamplePath, 'adts-mpeg4.aac'), 'audio/aac', {
           duration: true
         });
-        checkFormat(metadata.format, 'ADTS/MPEG-4', 'AAC', 'AAC LC', 16000, 1, 20399, 256000);
+        checkFormat(format, 'ADTS/MPEG-4', 'AAC', 'AAC LC', 16000, 1, 20399, 256000);
       });
     });
   });
@@ -39,10 +38,10 @@ describe('Parse ADTS/AAC', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const {metadata} = await parser.initParser(() => this.skip(), path.join(aacSamplePath, 'adts-mpeg4-2.aac'), 'audio/aac', {
+        const {format} = await parser.initParser(() => this.skip(), path.join(aacSamplePath, 'adts-mpeg4-2.aac'), 'audio/aac', {
           duration: true
         });
-        checkFormat(metadata.format, 'ADTS/MPEG-4', 'AAC', 'AAC LC', 44100, 2, 128000, 14336);
+        checkFormat(format, 'ADTS/MPEG-4', 'AAC', 'AAC LC', 44100, 2, 128000, 14336);
       });
     });
   });

--- a/test/test-file-aiff.ts
+++ b/test/test-file-aiff.ts
@@ -30,8 +30,8 @@ describe('Parse AIFF (Audio Interchange File Format)', () => {
       it(parser.description, async function(){
         // AIFF file, AIFF file, stereo 8-bit data
         // Source: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/Samples.html
-        const { metadata } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'M1F1-int8-AFsp.aif'), 'audio/aiff');
-        checkFormat(metadata.format, 'PCM', 8000, 2, 8, 23493);
+        const { format } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'M1F1-int8-AFsp.aif'), 'audio/aiff');
+        checkFormat(format, 'PCM', 8000, 2, 8, 23493);
       });
     });
   });
@@ -42,8 +42,8 @@ describe('Parse AIFF (Audio Interchange File Format)', () => {
       it(parser.description, async function(){
         // AIFF-C file, stereo A-law data (compression type: alaw)
         // Source: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/Samples.html
-        const { metadata } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'M1F1-AlawC-AFsp.aif'), 'audio/aiff');
-        checkFormat(metadata.format, 'Alaw 2:1', 8000, 2, 16, 23493);
+        const { format } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'M1F1-AlawC-AFsp.aif'), 'audio/aiff');
+        checkFormat(format, 'Alaw 2:1', 8000, 2, 16, 23493);
       });
     });
 
@@ -67,8 +67,8 @@ describe('Parse AIFF (Audio Interchange File Format)', () => {
 
       Parsers.forEach(parser => {
         it(parser.description, async function(){
-          const { metadata } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Pmiscck.aif'), 'audio/aiff');
-          checkFormat(metadata.format, ULAW, 8000, 1, 16, 9);
+          const { format } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Pmiscck.aif'), 'audio/aiff');
+          checkFormat(format, ULAW, 8000, 1, 16, 9);
         });
       });
     });
@@ -77,8 +77,8 @@ describe('Parse AIFF (Audio Interchange File Format)', () => {
 
       Parsers.forEach(parser => {
         it(parser.description, async function(){
-          const { metadata } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Pnossnd.aif'), 'audio/aiff');
-          checkFormat(metadata.format, ULAW, 8000, 1, 16, 0);
+          const { format } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Pnossnd.aif'), 'audio/aiff');
+          checkFormat(format, ULAW, 8000, 1, 16, 0);
         });
       });
     });
@@ -87,8 +87,8 @@ describe('Parse AIFF (Audio Interchange File Format)', () => {
 
       Parsers.forEach(parser => {
         it(parser.description, async function(){
-          const { metadata } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Poffset.aif'), 'audio/aiff');
-          checkFormat(metadata.format, ULAW, 8000, 1, 16, 9);
+          const { format } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Poffset.aif'), 'audio/aiff');
+          checkFormat(format, ULAW, 8000, 1, 16, 9);
         });
       });
     });
@@ -97,8 +97,8 @@ describe('Parse AIFF (Audio Interchange File Format)', () => {
 
       Parsers.forEach(parser => {
         it(parser.description, async function(){
-          const { metadata } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Porder.aif'), 'audio/aiff');
-          checkFormat(metadata.format, ULAW, 8000, 1, 16, 9);
+          const { format } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Porder.aif'), 'audio/aiff');
+          checkFormat(format, ULAW, 8000, 1, 16, 9);
         });
       });
     });
@@ -107,8 +107,8 @@ describe('Parse AIFF (Audio Interchange File Format)', () => {
 
       Parsers.forEach(parser => {
         it(parser.description, async function(){
-          const { metadata } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Ptjunk.aif'), 'audio/aiff');
-          checkFormat(metadata.format, ULAW, 8000, 1, 16, 9);
+          const { format } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Ptjunk.aif'), 'audio/aiff');
+          checkFormat(format, ULAW, 8000, 1, 16, 9);
         });
       });
     });
@@ -117,8 +117,8 @@ describe('Parse AIFF (Audio Interchange File Format)', () => {
 
       Parsers.forEach(parser => {
         it(parser.description, async function(){
-          const { metadata } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Fnonull.aif'), 'audio/aiff');
-          checkFormat(metadata.format, ULAW, 8000, 1, 16, 9);
+          const { format } = await parser.initParser(() => this.skip(), path.join(aiffSamplePath, 'Fnonull.aif'), 'audio/aiff');
+          checkFormat(format, ULAW, 8000, 1, 16, 9);
         });
       });
     });

--- a/test/test-file-ape.ts
+++ b/test/test-file-ape.ts
@@ -41,13 +41,12 @@ describe('Parse APE (Monkey\'s Audio)', () => {
 
   Parsers.forEach(parser => {
     it(parser.description, async function(){
-      const {metadata} = await parser.initParser(() => this.skip(), path.join(samplePath, 'monkeysaudio.ape'), 'audio/ape');
-      assert.isDefined(metadata, 'metadata should be defined');
-      checkFormat(metadata.format);
-      checkCommon(metadata.common);
-      assert.isDefined(metadata.native, 'metadata.native should be defined');
-      assert.isDefined(metadata.native.APEv2, 'metadata.native.APEv2 should be defined');
-      checkNative(mm.orderTags(metadata.native.APEv2));
+      const {format, common, native} = await parser.initParser(() => this.skip(), path.join(samplePath, 'monkeysaudio.ape'), 'audio/ape');
+      checkFormat(format);
+      checkCommon(common);
+      assert.isDefined(native, 'metadata.native should be defined');
+      assert.isDefined(native.APEv2, 'metadata.native.APEv2 should be defined');
+      checkNative(mm.orderTags(native.APEv2));
     });
   });
 

--- a/test/test-file-asf.ts
+++ b/test/test-file-asf.ts
@@ -108,13 +108,12 @@ describe('Parse ASF', () => {
 
       Parsers.forEach(parser => {
         it(parser.description, async function(){
-          const {metadata} = await parser.initParser(() => this.skip(), path.join(asfFilePath, 'asf.wma'), 'audio/x-ms-wma');
-          assert.isDefined(metadata, 'metadata');
-          checkFormat(metadata.format);
-          checkCommon(metadata.common);
-          assert.isDefined(metadata.native, 'metadata.native');
-          assert.isDefined(metadata.native.asf, 'should include native ASF tags');
-          checkNative(mm.orderTags(metadata.native.asf));
+          const {format, common, native} = await parser.initParser(() => this.skip(), path.join(asfFilePath, 'asf.wma'), 'audio/x-ms-wma');
+          checkFormat(format);
+          checkCommon(common);
+          assert.isDefined(native, 'metadata.native');
+          assert.isDefined(native.asf, 'should include native ASF tags');
+          checkNative(mm.orderTags(native.asf));
         });
       });
 
@@ -125,8 +124,8 @@ describe('Parse ASF', () => {
       Parsers.forEach(parser => {
         it(parser.description, async function(){
           const filePath = path.join(asfFilePath, 'issue_57.wma');
-          const {metadata} = await parser.initParser(() => this.skip(), filePath, 'audio/x-ms-wma');
-          const asf = mm.orderTags(metadata.native.asf);
+          const {native} = await parser.initParser(() => this.skip(), filePath, 'audio/x-ms-wma');
+          const asf = mm.orderTags(native.asf);
           assert.exists(asf['WM/Picture'][0], 'ASF WM/Picture should be set');
           const nativePicture = asf['WM/Picture'][0];
           assert.exists((nativePicture as IPicture).data);

--- a/test/test-file-flac.ts
+++ b/test/test-file-flac.ts
@@ -60,10 +60,10 @@ describe('Parse FLAC Vorbis comment', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const {metadata} = await parser.initParser(this.skip(), path.join(samplePath, 'flac.flac'), 'audio/flac');
-        checkFormat(metadata.format);
-        checkCommon(metadata.common);
-        checkNative(mm.orderTags(metadata.native.vorbis));
+        const {format, common, native} = await parser.initParser(this.skip(), path.join(samplePath, 'flac.flac'), 'audio/flac');
+        checkFormat(format);
+        checkCommon(common);
+        checkNative(mm.orderTags(native.vorbis));
       });
     });
 
@@ -75,8 +75,8 @@ describe('Parse FLAC Vorbis comment', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const {metadata} = await parser.initParser(this.skip(), filePath, 'audio/flac');
-        t.deepEqual(metadata.format.tagTypes, ['ID3v2.3', 'vorbis', 'ID3v1'], 'File has 3 tag types: "vorbis", "ID3v2.3" & "ID3v1"');
+        const {format} = await parser.initParser(this.skip(), filePath, 'audio/flac');
+        t.deepEqual(format.tagTypes, ['ID3v2.3', 'vorbis', 'ID3v1'], 'File has 3 tag types: "vorbis", "ID3v2.3" & "ID3v1"');
       });
     });
 
@@ -88,8 +88,8 @@ describe('Parse FLAC Vorbis comment', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const {metadata} = await parser.initParser(() => this.skip(), filePath, 'audio/flac');
-        assert.approximately(496000, metadata.format.bitrate, 500);
+        const {format} = await parser.initParser(() => this.skip(), filePath, 'audio/flac');
+        assert.approximately(496000, format.bitrate, 500);
       });
     });
 

--- a/test/test-file-mp3.ts
+++ b/test/test-file-mp3.ts
@@ -106,9 +106,7 @@ describe('Parse MP3 files', () => {
 
   });
 
-  it('should handle audio-frame-header-bug', function() {
-
-    this.timeout(15000); // It takes a long time to parse
+  it('should handle audio-frame-header-bug', () => {
 
     const filePath = path.join(samplePath, 'audio-frame-header-bug.mp3');
 
@@ -117,9 +115,7 @@ describe('Parse MP3 files', () => {
     });
   });
 
-  it('should be able to parse: Sleep Away.mp3', function() {
-
-    this.timeout(15000); // Parsing this file can take a bit longer
+  it('should be able to parse: Sleep Away.mp3', () => {
 
     const filePath = path.join(mp3SamplePath, 'Sleep Away.mp3');
 
@@ -257,8 +253,8 @@ describe('Parse MP3 files', () => {
           .filter(parser => !parser.webStream)
           .forEach(parser => {
             it(parser.description, async function(){
-              const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {duration: false});
-              assert.isUndefined(metadata.format.duration, 'Don\'t expect a duration');
+              const { format } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {duration: false});
+              assert.isUndefined(format.duration, 'Don\'t expect a duration');
             });
           });
       });
@@ -271,8 +267,7 @@ describe('Parse MP3 files', () => {
           .filter(parser => !parser.webStream)
           .forEach(parser => {
             it(parser.description, async function(){
-              const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {duration: true});
-              const { format } = metadata;
+              const { format } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {duration: true});
               assert.approximately(format.duration, durationSleepAwayMp3, 1 / 10, 'Expect a duration');
               assert.strictEqual(format.numberOfSamples, 8831232, 'format.numberOfSamples');
             });

--- a/test/test-file-mp4.ts
+++ b/test/test-file-mp4.ts
@@ -74,13 +74,12 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
         const filePath = path.join(mp4Samples, 'id4.m4a');
 
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mp4');
-        const native = metadata.native.iTunes;
+        const { native, format, common } = await parser.initParser(() => this.skip(), filePath, 'audio/mp4');
         assert.ok(native, 'Native m4a tags should be present');
 
-        checkFormat(metadata.format);
-        checkCommon(metadata.common);
-        checkNativeTags(mm.orderTags(native));
+        checkFormat(format);
+        checkCommon(common);
+        checkNativeTags(mm.orderTags(native.iTunes));
       });
     });
   });
@@ -95,8 +94,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
         const filePath = path.join(mp4Samples, 'issue-74.m4a');
 
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mp4');
-        const {format, common, native} = metadata;
+        const {format, common, native} = await parser.initParser(() => this.skip(), filePath, 'audio/mp4');
 
         assert.deepEqual(format.container, 'isom/iso2/mp41', 'format.container');
         assert.deepEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
@@ -124,8 +122,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
         const filePath = path.join(mp4Samples, 'issue-79.m4a');
 
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mp4');
-        const {common, format} = metadata;
+        const {common, format} = await parser.initParser(() => this.skip(), filePath, 'audio/mp4');
 
         assert.deepEqual(format.container, 'M4A/mp42/isom', 'format.container');
         assert.deepEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
@@ -154,8 +151,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
           const filePath = path.join(mp4Samples, 'issue-127.m4b');
 
-          const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mp4');
-          const { common, format} = metadata;
+          const { common, format, native} = await parser.initParser(() => this.skip(), filePath, 'audio/mp4');
 
           assert.deepEqual(format.container, 'M4A/3gp5/isom', 'format.container');
           assert.deepEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
@@ -168,7 +164,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
           assert.deepEqual(common.track, {no: 1, of: null});
           assert.deepEqual(common.comment, [{text: 'https://archive.org/details/glories_of_ireland_1801_librivox'}]);
 
-          const iTunes = mm.orderTags(metadata.native.iTunes);
+          const iTunes = mm.orderTags(native.iTunes);
           assert.deepEqual(iTunes.stik, [2], 'iTunes.stik = 2 = Audiobook'); // Ref: http://www.zoyinc.com/?p=1004
         });
       });
@@ -296,8 +292,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
           const filePath = path.join(mp4Samples, 'Mr. Pickles S02E07 My Dear Boy.mp4');
 
-          const { metadata } = await parser.initParser(() => this.skip(), filePath, 'video/mp4');
-          const { common, format } = metadata;
+          const { common, format, native } = await parser.initParser(() => this.skip(), filePath, 'video/mp4');
           assert.deepEqual(common.title, 'My Dear Boy');
           assert.deepEqual(common.tvEpisode, 7);
           assert.deepEqual(common.tvEpisodeId, '017');
@@ -311,7 +306,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
           assert.deepEqual(common.albumartist, 'Mr. Pickles');
           assert.deepEqual(common.copyright, '© & TM - Cartoon Network - 2016');
 
-          const iTunes = mm.orderTags(metadata.native.iTunes);
+          const iTunes = mm.orderTags(native.iTunes);
           assert.deepEqual(iTunes.stik, [10], 'iTunes.stik = 10 = TV Show'); // Ref: http://www.zoyinc.com/?p=1004
         });
       });
@@ -325,9 +320,9 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
         const filePath = path.join(mp4Samples, 'issue-133.m4a');
 
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'video/mp4');
-        assert.deepEqual(metadata.format.container, 'M4A/mp42/isom', 'format.container');
-        assert.deepEqual(metadata.format.codec, 'MPEG-4/AAC', 'format.codec');
+        const { format } = await parser.initParser(() => this.skip(), filePath, 'video/mp4');
+        assert.deepEqual(format.container, 'M4A/mp42/isom', 'format.container');
+        assert.deepEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
       });
     });
   });
@@ -341,17 +336,17 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
         const filePath = path.join(mp4Samples, 'issue-151.m4a');
 
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'video/mp4');
-        assert.deepEqual(metadata.format.container, 'mp42/isom', 'format.container');
-        assert.deepEqual(metadata.format.codec, 'MPEG-4/AAC+MP4S', 'format.codec');
+        const { format, common } = await parser.initParser(() => this.skip(), filePath, 'video/mp4');
+        assert.deepEqual(format.container, 'mp42/isom', 'format.container');
+        assert.deepEqual(format.codec, 'MPEG-4/AAC+MP4S', 'format.codec');
 
-        assert.deepEqual(metadata.common.album, 'We Don`t Need to Whisper');
-        assert.deepEqual(metadata.common.albumartist, 'Angels and Airwaves');
-        assert.deepEqual(metadata.common.artist, 'Angels and Airwaves');
-        assert.deepEqual(metadata.common.artists, ['Angels and Airwaves']);
-        assert.strictEqual(metadata.common.bpm, 89);
-        assert.deepEqual(metadata.common.genre, ['Rock']);
-        assert.strictEqual(metadata.common.title, 'Distraction');
+        assert.deepEqual(common.album, 'We Don`t Need to Whisper');
+        assert.deepEqual(common.albumartist, 'Angels and Airwaves');
+        assert.deepEqual(common.artist, 'Angels and Airwaves');
+        assert.deepEqual(common.artists, ['Angels and Airwaves']);
+        assert.strictEqual(common.bpm, 89);
+        assert.deepEqual(common.genre, ['Rock']);
+        assert.strictEqual(common.title, 'Distraction');
       });
 
     });
@@ -365,8 +360,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
       it(parser.description, async function(){
         const filePath = path.join(mp4Samples, '01. Trumpsta (Djuro Remix).m4a');
 
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/m4a');
-        const { format, common } = metadata;
+        const { format, common } = await parser.initParser(() => this.skip(), filePath, 'audio/m4a');
 
         assert.deepEqual(format.container, 'M4A/mp42/isom', 'format.container');
         assert.deepEqual(format.codec, 'MPEG-4/AAC', 'format.codec');

--- a/test/test-file-mpeg.ts
+++ b/test/test-file-mpeg.ts
@@ -51,18 +51,14 @@ describe('Parse MPEG', () => {
     const emptyStreamSize = 5 * 1024 * 1024;
     const buf = new Uint8Array(emptyStreamSize).fill(0);
 
-    it('should sync efficient from a stream', async function() {
-
-      this.timeout(10000); // It takes a log time to parse, due to sync errors and assumption it is VBR (which is caused by the funny 224 kbps frame)
+    it('should sync efficient from a stream', async () => {
 
       const streamReader = new SourceStream(buf);
 
       await mm.parseStream(streamReader, {mimeType: 'audio/mpeg'}, {duration: true});
     });
 
-    it('should sync efficient, from a file', async function() {
-
-      this.timeout(10000); // It takes a log time to parse, due to sync errors and assumption it is VBR (which is caused by the funny 224 kbps frame)
+    it('should sync efficient, from a file', async () => {
 
       const tmpFilePath = path.join(samplePath, 'zeroes.mp3');
 
@@ -78,14 +74,13 @@ describe('Parse MPEG', () => {
 
   describe('mpeg parsing fails for irrelevant attributes #14', () => {
 
-    it('should decode 04 - You Don\'t Know.mp3', async function() {
+    it('should decode 04 - You Don\'t Know.mp3', async () => {
 
       /**
        * File has id3v2.3 & id3v1 tags
        * First frame is 224 kbps, rest 320 kbps
        * After id3v2.3, lots of 0 padding
        */
-      this.timeout(15000); // It takes a long time to parse, due to sync errors and assumption it is VBR (which is caused by the funny 224 kbps frame)
 
       const filePath = path.join(samplePath, '04 - You Don\'t Know.mp3');
 
@@ -151,12 +146,10 @@ describe('Parse MPEG', () => {
 
     });
 
-    it('should decode 07 - I\'m Cool.mp3', async function() {
+    it('should decode 07 - I\'m Cool.mp3', async () => {
       // 'LAME3.91' found on position 81BCF=531407
 
       const filePath = path.join(samplePath, '07 - I\'m Cool.mp3');
-
-      this.timeout(15000); // It takes a long time to parse
 
       function checkFormat(format) {
         t.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.type');
@@ -343,8 +336,8 @@ describe('Parse MPEG', () => {
       Parsers
         .forEach(parser => {
           it(parser.description, async function(){
-            const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {duration: false});
-            assert.strictEqual(metadata.format.duration, 0.4963265306122449);
+            const { format } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {duration: false});
+            assert.strictEqual(format.duration, 0.4963265306122449);
           });
         });
 

--- a/test/test-file-musepack.ts
+++ b/test/test-file-musepack.ts
@@ -15,9 +15,8 @@ describe('Parse Musepack (.mpc)', () => {
     Parsers.forEach(parser => {
       it(parser.description, async function(){
 
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/musepac');
+        const { format, common } = await parser.initParser(() => this.skip(), filePath, 'audio/musepac');
         // Check format
-        const { format, common } = metadata;
         assert.deepEqual(format.container, 'Musepack, SV7');
         assert.strictEqual(format.sampleRate, 44100);
         assert.strictEqual(format.numberOfSamples, 11940);
@@ -49,8 +48,7 @@ describe('Parse Musepack (.mpc)', () => {
     Parsers.forEach(parser => {
       it(parser.description, async function(){
 
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/musepac');
-        const { format, common } = metadata;
+        const { format, common } = await parser.initParser(() => this.skip(), filePath, 'audio/musepac');
         // Check format
         assert.deepEqual(format.container, 'Musepack, SV7');
         assert.strictEqual(format.sampleRate, 44100);
@@ -76,8 +74,7 @@ describe('Parse Musepack (.mpc)', () => {
     Parsers.forEach(parser => {
       it(parser.description, async function(){
 
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/musepac');
-        const { format, common } = metadata;
+        const { format, common } = await parser.initParser(() => this.skip(), filePath, 'audio/musepac');
         // Check format
         assert.deepEqual(format.container, 'Musepack, SV8');
         assert.strictEqual(format.sampleRate, 48000);

--- a/test/test-file-ogg.ts
+++ b/test/test-file-ogg.ts
@@ -8,9 +8,7 @@ import { IdHeader } from '../lib/ogg/opus/Opus.js';
 
 const oggSamplePath = path.join(samplePath, 'ogg');
 
-describe('Parse Ogg', function() {
-
-  this.timeout(15000); // It takes a log time to parse, due to sync errors and assumption it is VBR (which is caused by the funny 224 kbps frame)
+describe('Parse Ogg', () => {
 
   function check_Nirvana_In_Bloom_commonTags(common) {
     assert.strictEqual(common.title, 'In Bloom', 'common.title');
@@ -66,10 +64,10 @@ describe('Parse Ogg', function() {
 
       Parsers.forEach(parser => {
         it(parser.description, async function(){
-          const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/ogg');
-          checkFormat(metadata.format);
-          check_Nirvana_In_Bloom_VorbisTags(mm.orderTags(metadata.native.vorbis));
-          check_Nirvana_In_Bloom_commonTags(metadata.common);
+          const { format, native, common } = await parser.initParser(() => this.skip(), filePath, 'audio/ogg');
+          checkFormat(format);
+          check_Nirvana_In_Bloom_VorbisTags(mm.orderTags(native.vorbis));
+          check_Nirvana_In_Bloom_commonTags(common);
         });
       });
 
@@ -149,10 +147,10 @@ describe('Parse Ogg', function() {
 
       Parsers.forEach(parser => {
         it(parser.description, async function(){
-          const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/ogg');
-          checkFormat(metadata.format);
-          check_Nirvana_In_Bloom_VorbisTags(mm.orderTags(metadata.native.vorbis));
-          check_Nirvana_In_Bloom_commonTags(metadata.common);
+          const { format, native, common } = await parser.initParser(() => this.skip(), filePath, 'audio/ogg');
+          checkFormat(format);
+          check_Nirvana_In_Bloom_VorbisTags(mm.orderTags(native.vorbis));
+          check_Nirvana_In_Bloom_commonTags(common);
         });
       });
 
@@ -173,8 +171,8 @@ describe('Parse Ogg', function() {
 
       Parsers.forEach(parser => {
         it(parser.description, async function(){
-          const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/ogg');
-          checkFormat(metadata.format);
+          const { format } = await parser.initParser(() => this.skip(), filePath, 'audio/ogg');
+          checkFormat(format);
         });
       });
 

--- a/test/test-file-wavpack.ts
+++ b/test/test-file-wavpack.ts
@@ -28,9 +28,9 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const { metadata } = await parser.initParser(() => this.skip(), wv1, 'audio/x-wavpack');
-        checkFormat(metadata.format);
-        checkCommon(metadata.common);
+        const { format, common } = await parser.initParser(() => this.skip(), wv1, 'audio/x-wavpack');
+        checkFormat(format);
+        checkCommon(common);
       });
     });
   });
@@ -50,8 +50,8 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const { metadata } = await parser.initParser(() => this.skip(), wv1, 'audio/x-wavpack');
-        checkFormat(metadata.format);
+        const { format } = await parser.initParser(() => this.skip(), wv1, 'audio/x-wavpack');
+        checkFormat(format);
       });
     });
   });
@@ -72,8 +72,8 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const { metadata } = await parser.initParser(() => this.skip(), wv1, 'audio/x-wavpack');
-        checkFormat(metadata.format);
+        const { format } = await parser.initParser(() => this.skip(), wv1, 'audio/x-wavpack');
+        checkFormat(format);
       });
     });
   });

--- a/test/test-http.ts
+++ b/test/test-http.ts
@@ -7,11 +7,7 @@ import type { IFileInfo } from 'strtok3';
 const [nodeMajorVersion] = process.versions.node.split('.').map(Number);
 
 // Skipped: https://github.com/Borewit/music-metadata/issues/160
-describe('HTTP streaming', function() {
-
-  // Increase time-out to 15 seconds because we retrieve files over HTTP(s)
-  this.timeout(15 * 1000);
-  this.retries(3); // Workaround for HTTP time-outs on Travis-CI
+describe('HTTP streaming', () => {
 
   describe("Stream HTTP using fetch()", () => {
 
@@ -22,8 +18,6 @@ describe('HTTP streaming', function() {
         if (nodeMajorVersion < 20) {
           this.skip(); // Fetch is only available since Node.js version 20
         }
-
-        this.timeout(10000);
 
         const url = 'http://builds.tokyo.s3.amazonaws.com/sample.m4a';
 
@@ -47,6 +41,6 @@ describe('HTTP streaming', function() {
         assert.strictEqual(tags.common.album, 'SUPER MARIO GALAXY ORIGINAL SOUNDTRACK');
       });
     });
-  });
+  }).retries(3); // Workaround for HTTP time-outs on Travis-CI
 
 });

--- a/test/test-id3v1.1.ts
+++ b/test/test-id3v1.1.ts
@@ -40,9 +40,9 @@ describe('Parsing MPEG / ID3v1', () => {
      */
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const { metadata } = await parser.initParser(() => this.skip(), fileBloodSugar, 'audio/mpeg');
-        checkFormat(metadata.format);
-        checkCommon(metadata.common);
+        const { format, common } = await parser.initParser(() => this.skip(), fileBloodSugar, 'audio/mpeg');
+        checkFormat(format);
+        checkCommon(common);
       });
     });
   });
@@ -52,9 +52,8 @@ describe('Parsing MPEG / ID3v1', () => {
     const filePath = path.join(samplePath, '07 - I\'m Cool.mp3');
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        this.timeout(15000); // Can take a bit longer
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {skipPostHeaders: true});
-        assert.deepEqual(metadata.format.tagTypes, ['ID3v2.3'], 'format.tagTypes');
+        const { format } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {skipPostHeaders: true});
+        assert.deepEqual(format.tagTypes, ['ID3v2.3'], 'format.tagTypes');
       });
     });
   });
@@ -76,8 +75,8 @@ describe('Parsing MPEG / ID3v1', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg');
-        checkFormat(metadata.format);
+        const { format } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg');
+        checkFormat(format);
       });
     });
   });
@@ -114,10 +113,9 @@ describe('Parsing MPEG / ID3v1', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg');
-        assert.isDefined(metadata, 'should provide metadata');
-        checkFormat(metadata.format);
-        checkCommon(metadata.common);
+        const { format, common } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg');
+        checkFormat(format);
+        checkCommon(common);
       });
     });
 
@@ -132,8 +130,8 @@ describe('Parsing MPEG / ID3v1', () => {
 
     Parsers.forEach(parser => {
       it(parser.description, async function(){
-        const { metadata } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {duration: true});
-        const id3v1 = mm.orderTags(metadata.native.ID3v1);
+        const { native } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg', {duration: true});
+        const id3v1 = mm.orderTags(native.ID3v1);
         assert.deepEqual(id3v1.title, ['Skupinove foto'], 'id3v1.title');
         assert.deepEqual(id3v1.artist, ['Pavel Dobes'], 'id3v1.artist');
         assert.deepEqual(id3v1.album, ['Skupinove foto'], 'id3v1.album');

--- a/test/test-regress-GH-56.ts
+++ b/test/test-regress-GH-56.ts
@@ -34,30 +34,30 @@ describe('should calculate duration for a CBR encoded MP3', () => {
 
   Parsers.forEach(parser => {
     it(parser.description, async function(){
-      const { metadata, randomRead } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg');
-      const expectedTags = randomRead ? ['ID3v2.3', 'APEv2'] : ['ID3v2.3'];
-      t.deepEqual(metadata.format.tagTypes, expectedTags, 'format.tagTypes');
-      t.strictEqual(metadata.format.sampleRate, 44100, 'format.sampleRate');
-      t.strictEqual(metadata.format.duration, 16462080 / metadata.format.sampleRate, 'format.duration');
+      const { format } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg');
+      const expectedTags = parser.randomRead ? ['ID3v2.3', 'APEv2'] : ['ID3v2.3'];
+      t.deepEqual(format.tagTypes, expectedTags, 'format.tagTypes');
+      t.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
+      t.strictEqual(format.duration, 16462080 / format.sampleRate, 'format.duration');
     });
   });
 
   it('_parseFile', async function(){
     const parser = Parsers[0];
-    const { metadata, randomRead } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg');
-    const expectedTags = randomRead ? ['ID3v2.3', 'APEv2'] : ['ID3v2.3'];
-    t.deepEqual(metadata.format.tagTypes, expectedTags, 'format.tagTypes');
-    t.strictEqual(metadata.format.sampleRate, 44100, 'format.sampleRate');
-    t.strictEqual(metadata.format.duration, 16462080 / metadata.format.sampleRate, 'format.duration');
+    const { format} = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg');
+    const expectedTags = parser.randomRead ? ['ID3v2.3', 'APEv2'] : ['ID3v2.3'];
+    t.deepEqual(format.tagTypes, expectedTags, 'format.tagTypes');
+    t.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
+    t.strictEqual(format.duration, 16462080 / format.sampleRate, 'format.duration');
   });
 
   it('debug single', async function(){
     const parser =  Parsers[3];
-    const { metadata, randomRead } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg');
-    const expectedTags = randomRead ? ['ID3v2.3', 'APEv2'] : ['ID3v2.3'];
-    t.deepEqual(metadata.format.tagTypes, expectedTags, 'format.tagTypes');
-    t.strictEqual(metadata.format.sampleRate, 44100, 'format.sampleRate');
-    t.strictEqual(metadata.format.duration, 16462080 / metadata.format.sampleRate, 'format.duration');
+    const { format } = await parser.initParser(() => this.skip(), filePath, 'audio/mpeg');
+    const expectedTags = parser.randomRead ? ['ID3v2.3', 'APEv2'] : ['ID3v2.3'];
+    t.deepEqual(format.tagTypes, expectedTags, 'format.tagTypes');
+    t.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
+    t.strictEqual(format.duration, 16462080 / format.sampleRate, 'format.duration');
   });
 
 });


### PR DESCRIPTION
In unit tests: move attribute `randomRead` from parsing result, to parser level