### PR TITLE
Fix tokenizer closure

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,7 +23,12 @@ const debug = initDebug('music-metadata:parser');
  */
 export async function parseStream(stream: Readable, fileInfo?: IFileInfo | string, options: IOptions = {}): Promise<IAudioMetadata> {
   const tokenizer = await fromStream(stream, {fileInfo: typeof fileInfo === 'string' ? {mimeType: fileInfo} : fileInfo});
-  return parseFromTokenizer(tokenizer, options);
+  try {
+    return await parseFromTokenizer(tokenizer, options);
+  }
+  finally {
+    await tokenizer.close();
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes the following error thrown:

```
TypeError: Invalid state: ReadableStream is locked
```
thrown when closing a `ReadableStream` passed to `parseWebStream()`.
