### PR TITLE
Remove CommonJS entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ For older Node.js version < 22, you need to dynamically import **music-metadata*
 
 For CommonJS TypeScript projects, using a Node.js version < 22, you can use [load-esm](https://github.com/Borewit/load-esm):
 
-This method shall replace the embedded CJS loader `loadMusicMetadata()` function.
+This method shall has replaced the embedded CJS loader function: `loadMusicMetadata()`.
 
 ```js
 import {loadEsm} from 'load-esm';
@@ -796,9 +796,6 @@ import {loadEsm} from 'load-esm';
   const mm = await loadEsm<typeof import('music-metadata')>('music-metadata');
 })();
 ```
-
-> [!NOTE]
-> The `loadMusicMetadata` function is experimental.
 
 ## Frequently Asked Questions
 

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -124,5 +124,3 @@ export async function scanAppendingHeaders(tokenizer: IRandomAccessTokenizer, op
 
   options.apeHeader = await APEv2Parser.findApeFooterOffset(tokenizer, apeOffset);
 }
-
-export declare function loadMusicMetadata(): Promise<typeof import('music-metadata')>;

--- a/lib/default.cjs
+++ b/lib/default.cjs
@@ -1,5 +1,0 @@
-// CommonJS core (default) entry point
-"use strict";
-module.exports = {
-  loadMusicMetadata: () => import('./core.js'),
-};

--- a/lib/node.cjs
+++ b/lib/node.cjs
@@ -1,5 +1,0 @@
-// CommonJS Node entry point
-"use strict";
-module.exports = {
-  loadMusicMetadata: () => import('./index.js'),
-};

--- a/package.json
+++ b/package.json
@@ -21,21 +21,18 @@
     "node": {
       "import": "./lib/index.js",
       "module-sync": "./lib/index.js",
-      "require": "./lib/node.cjs",
       "types": "./lib/index.d.ts"
     },
     "default": {
       "import": "./lib/core.js",
       "module-sync": "./lib/core.js",
-      "require": "./lib/default.cjs",
       "types": "./lib/core.d.ts"
     }
   },
   "types": "lib/index.d.ts",
   "files": [
     "lib/**/*.js",
-    "lib/**/*.d.ts",
-    "lib/*.cjs"
+    "lib/**/*.d.ts"
   ],
   "keywords": [
     "music",


### PR DESCRIPTION
`loadMusicMetadata()` no longer available. 
[load-esm](https://github.com/Borewit/load-esm) can be used instead.

Replace
```ts
import {loadMusicMetadata} from 'music-metadata';

(async () => {
  const mm = await loadMusicMetadata();
})();
```

with:

```bash
npm install load-esm
```

```ts
import {loadEsm} from 'load-esm';

(async () => {
  const mm = await loadEsm<typeof import('music-metadata')>('music-metadata');
})();
```

Benefits:
- One generic shared solution which works for importing any pure ESM project 
- Avoid CommonJS and ESM typings getting mixed up 