### PR TITLE
Workaround for TypeScript bundler node-resolution

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -124,3 +124,11 @@ export async function scanAppendingHeaders(tokenizer: IRandomAccessTokenizer, op
 
   options.apeHeader = await APEv2Parser.findApeFooterOffset(tokenizer, apeOffset);
 }
+
+/**
+ * Implementation only available when loaded as Node.js
+ * This method will throw an Error, always.
+ */
+export async function parseFile(filePath: string, options: IOptions = {}): Promise<IAudioMetadata> {
+  throw new Error('To load Web API File objects use parseBlob instead. For loading files, you need to import with the "node" condition is set.');
+}


### PR DESCRIPTION
Add stub to fool TypeScript compiler, loading the wrong entry points for the typings.

For calling the runtime problems, it throws an error.

Change suggested by @net: https://github.com/Borewit/music-metadata/issues/2370#issuecomment-2711251879