### PR TITLE
refactor: enable erasableSyntaxOnly/remove enum usage

### DIFF
--- a/doc-gen/MarkDown.ts
+++ b/doc-gen/MarkDown.ts
@@ -1,7 +1,10 @@
 import type * as fs from 'node:fs';
 
 export class Row {
-  constructor(public values: string[]) {
+  public values: string[];
+
+  constructor(values: string[]) {
+    this.values = values;
   }
 }
 

--- a/lib/ParseError.ts
+++ b/lib/ParseError.ts
@@ -25,8 +25,11 @@ export class UnsupportedFileTypeError extends makeParseError('UnsupportedFileTyp
 
 // Concrete error class representing unexpected file content.
 class UnexpectedFileContentError extends makeParseError('UnexpectedFileContentError') {
-  constructor(public readonly fileType: string, message: string) {
+  public readonly fileType: string;
+
+  constructor(fileType: string, message: string) {
     super(message);
+    this.fileType = fileType;
   }
 
   // Override toString to include file type information.

--- a/lib/aiff/AiffToken.ts
+++ b/lib/aiff/AiffToken.ts
@@ -41,7 +41,10 @@ export class Common implements IGetToken<ICommon> {
 
   public len: number;
 
-  public constructor(header: iff.IChunkHeader, private isAifc: boolean) {
+  private isAifc: boolean;
+
+  public constructor(header: iff.IChunkHeader, isAifc: boolean) {
+    this.isAifc = isAifc;
     const minimumChunkSize = isAifc ? 22 : 18;
     if (header.chunkSize < minimumChunkSize) throw new AiffContentError(`COMMON CHUNK size should always be at least ${minimumChunkSize}`);
     this.len = header.chunkSize;

--- a/lib/apev2/APEv2Token.ts
+++ b/lib/apev2/APEv2Token.ts
@@ -83,12 +83,13 @@ export interface IFooter {
   flags: ITagFlags // ToDo: what is this???
 }
 
-export enum DataType {
-  text_utf8 = 0,
-  binary = 1,
-  external_info = 2,
-  reserved = 3
+export const DataType = {
+  text_utf8: 0,
+  binary: 1,
+  external_info: 2,
+  reserved: 3
 }
+export type DataType = typeof DataType[keyof typeof DataType]
 
 /**
  * APE_DESCRIPTOR: defines the sizes (and offsets) of all the pieces, as well as the MD5 checksum

--- a/lib/asf/AsfObject.ts
+++ b/lib/asf/AsfObject.ts
@@ -587,7 +587,10 @@ export class WmPictureToken implements IGetToken<IWmPicture> {
     return pic.get(buffer, 0);
   }
 
-  constructor(public len: number) {
+  public len: number;
+
+  constructor(len: number) {
+    this.len = len;
   }
 
   public get(buffer: Uint8Array, offset: number): IWmPicture {

--- a/lib/asf/AsfObject.ts
+++ b/lib/asf/AsfObject.ts
@@ -16,32 +16,33 @@ export class AsfContentParseError extends makeUnexpectedFileContentError('ASF'){
 /**
  * Data Type: Specifies the type of information being stored. The following values are recognized.
  */
-export enum DataType {
+export const DataType = {
   /**
    * Unicode string. The data consists of a sequence of Unicode characters.
    */
-  UnicodeString = 0,
+  UnicodeString: 0,
   /**
    * BYTE array. The type of data is implementation-specific.
    */
-  ByteArray = 1,
+  ByteArray: 1,
   /**
    * BOOL. The data is 2 bytes long and should be interpreted as a 16-bit unsigned integer. Only 0x0000 or 0x0001 are permitted values.
    */
-  Bool = 2,
+  Bool: 2,
   /**
    * DWORD. The data is 4 bytes long and should be interpreted as a 32-bit unsigned integer.
    */
-  DWord = 3,
+  DWord: 3,
   /**
    * QWORD. The data is 8 bytes long and should be interpreted as a 64-bit unsigned integer.
    */
-  QWord = 4,
+  QWord: 4,
   /**
    * WORD. The data is 2 bytes long and should be interpreted as a 16-bit unsigned integer.
    */
-  Word = 5
+  Word: 5
 }
+export type DataType = typeof DataType[keyof typeof DataType]
 
 /**
  * Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/ee663575
@@ -607,7 +608,7 @@ export class WmPictureToken implements IGetToken<IWmPicture> {
     const description = new Token.StringType(index - 5, 'utf-16le').get(buffer, 5);
 
     return {
-      type: AttachedPictureType[typeId],
+      type: AttachedPictureType[typeId as keyof typeof AttachedPictureType],
       format,
       description,
       size,

--- a/lib/asf/GUID.ts
+++ b/lib/asf/GUID.ts
@@ -118,7 +118,10 @@ export default class GUID {
     return bin;
   }
 
-  public constructor(public str: string) {
+  public str: string;
+
+  public constructor(str: string) {
+    this.str = str;
   }
 
   public equals(guid: GUID) {

--- a/lib/common/BasicParser.ts
+++ b/lib/common/BasicParser.ts
@@ -6,6 +6,12 @@ import type { INativeMetadataCollector } from './MetadataCollector.js';
 
 export abstract class BasicParser implements ITokenParser {
 
+  protected readonly metadata: INativeMetadataCollector;
+
+  protected readonly tokenizer: ITokenizer;
+  
+  protected readonly options: IOptions;
+
   /**
    * Initialize parser with output (metadata), input (tokenizer) & parsing options (options).
    * @param {INativeMetadataCollector} metadata Output
@@ -13,10 +19,13 @@ export abstract class BasicParser implements ITokenParser {
    * @param {IOptions} options Parsing options
    */
   constructor(
-    protected readonly metadata: INativeMetadataCollector,
-    protected readonly tokenizer: ITokenizer,
-    protected readonly options: IOptions
+    metadata: INativeMetadataCollector,
+    tokenizer: ITokenizer,
+    options: IOptions
   ) {
+    this.metadata = metadata;
+    this.tokenizer = tokenizer;
+    this.options = options;
   }
 
   public abstract parse(): Promise<void>;

--- a/lib/common/GenericTagMapper.ts
+++ b/lib/common/GenericTagMapper.ts
@@ -43,7 +43,13 @@ export class CommonTagMapper implements IGenericTagMapper {
     };
   }
 
-  public constructor(public tagTypes: generic.TagType[], public tagMap: generic.INativeTagMap) {
+  public tagTypes: generic.TagType[];
+
+  public tagMap: generic.INativeTagMap;
+
+  public constructor(tagTypes: generic.TagType[], tagMap: generic.INativeTagMap) {
+    this.tagTypes = tagTypes;
+    this.tagMap = tagMap;
   }
 
   /**

--- a/lib/common/MetadataCollector.ts
+++ b/lib/common/MetadataCollector.ts
@@ -92,7 +92,10 @@ export class MetadataCollector implements INativeMetadataCollector {
 
   private tagMapper = new CombinedTagMapper();
 
-  public constructor(private opts?: IOptions) {
+  private opts?: IOptions;
+
+  public constructor(opts?: IOptions) {
+    this.opts = opts;
     let priority = 1;
     for (const tagType of TagPriority) {
       this.originPriority[tagType] = priority++;

--- a/lib/common/MetadataCollector.ts
+++ b/lib/common/MetadataCollector.ts
@@ -2,7 +2,7 @@ import {
   type FormatId,
   type IAudioMetadata, type ICommonTagsResult,
   type IFormat,
-  type INativeTags, type IOptions, type IQualityInformation, type IPicture, type ITrackInfo, TrackType, type IComment, type AnyTagValue
+  type INativeTags, type IOptions, type IQualityInformation, type IPicture, type ITrackInfo, TrackTypeValueToKeyMap, type IComment, type AnyTagValue
 } from '../type.js';
 
 import initDebug from 'debug';
@@ -109,7 +109,7 @@ export class MetadataCollector implements INativeMetadataCollector {
   }
 
   public addStreamInfo(streamInfo: ITrackInfo) {
-    debug(`streamInfo: type=${streamInfo.type ? TrackType[streamInfo.type] : '?'}, codec=${streamInfo.codecName}`);
+    debug(`streamInfo: type=${streamInfo.type ? TrackTypeValueToKeyMap[streamInfo.type] : '?'}, codec=${streamInfo.codecName}`);
     this.format.trackInfo.push(streamInfo);
   }
 

--- a/lib/dsf/DsfChunk.ts
+++ b/lib/dsf/DsfChunk.ts
@@ -60,16 +60,16 @@ export const DsdChunk: IGetToken<IDsdChunk> = {
     };
   }
 };
-
-export enum ChannelType {
-  mono = 1,
-  stereo = 2,
-  channels = 3,
-  quad = 4,
-  '4 channels' = 5,
-  '5 channels' = 6,
-  '5.1 channels' = 7
+export const ChannelType = {
+  mono: 1,
+  stereo: 2,
+  channels: 3,
+  quad: 4,
+  '4 channels': 5,
+  '5 channels': 6,
+  '5.1 channels': 7
 }
+export type ChannelType = typeof ChannelType[keyof typeof ChannelType];
 
 /**
  * Interface to format chunk payload chunk

--- a/lib/ebml/EbmlIterator.ts
+++ b/lib/ebml/EbmlIterator.ts
@@ -18,13 +18,15 @@ export interface ILinkedElementType extends IElementType {
   readonly container?: { [id: number]: ILinkedElementType; };
 }
 
-export enum ParseAction {
-  ReadNext = 0,           // Continue reading the next elements
-  IgnoreElement = 2,      // Ignore (do not read) this element
-  SkipSiblings = 3,       // Skip all remaining elements at the same level
-  TerminateParsing = 4,   // Terminate the parsing process
-  SkipElement = 5         // Consider the element has read, assume position is at the next element
-}
+export const ParseAction = {
+  ReadNext: 0,           // Continue reading the next elements
+  IgnoreElement: 2,      // Ignore (do not read) this element
+  SkipSiblings: 3,       // Skip all remaining elements at the same level
+  TerminateParsing: 4,   // Terminate the parsing process
+  SkipElement: 5         // Consider the element has read, assume position is at the next element
+} as const;
+
+export type ParseAction = typeof ParseAction[keyof typeof ParseAction];
 
 /**
  * @return true, to quit the parser

--- a/lib/ebml/EbmlIterator.ts
+++ b/lib/ebml/EbmlIterator.ts
@@ -52,11 +52,14 @@ export class EbmlIterator {
   private ebmlMaxIDLength = 4;
   private ebmlMaxSizeLength = 8;
 
+  private tokenizer: ITokenizer;
+
   /**
    * @param {ITokenizer} tokenizer Input
    * @param tokenizer
    */
-  constructor(private tokenizer: ITokenizer) {
+  constructor(tokenizer: ITokenizer) {
+    this.tokenizer = tokenizer;
     this.parserMap.set(DataType.uint, e => this.readUint(e));
     this.parserMap.set(DataType.string, e => this.readString(e));
     this.parserMap.set(DataType.binary, e => this.readBuffer(e));

--- a/lib/ebml/types.ts
+++ b/lib/ebml/types.ts
@@ -1,6 +1,14 @@
 export interface ITree { [name: string]: string | number | boolean | Uint8Array | ITree | ITree[]; }
 
-export enum DataType { 'string' = 0, uint = 1, uid = 2, bool = 3, binary = 4, float = 5}
+export const DataType = {
+  string: 0,
+  uint: 1,
+  uid: 2,
+  bool: 3,
+  binary: 4,
+  float: 5,
+} as const;
+export type DataType = typeof DataType[keyof typeof DataType];
 
 export type ValueType = string | number | Uint8Array | boolean | ITree | ITree[];
 

--- a/lib/flac/FlacParser.ts
+++ b/lib/flac/FlacParser.ts
@@ -19,15 +19,16 @@ class FlacContentError extends makeUnexpectedFileContentError('FLAC'){
  * FLAC supports up to 128 kinds of metadata blocks; currently the following are defined:
  * ref: https://xiph.org/flac/format.html#metadata_block
  */
-enum BlockType {
-  STREAMINFO = 0,
-  PADDING = 1,
-  APPLICATION = 2,
-  SEEKTABLE = 3,
-  VORBIS_COMMENT = 4,
-  CUESHEET = 5,
-  PICTURE = 6
-}
+const BlockType = {
+  STREAMINFO: 0, // STREAMINFO
+  PADDING: 1, // PADDING
+  APPLICATION: 2, // APPLICATION
+  SEEKTABLE: 3, // SEEKTABLE
+  VORBIS_COMMENT: 4, // VORBIS_COMMENT
+  CUESHEET: 5, // CUESHEET
+  PICTURE: 6 // PICTURE
+};
+type BlockType = typeof BlockType[keyof typeof BlockType];
 
 export class FlacParser extends AbstractID3Parser {
 

--- a/lib/id3v1/ID3v1Parser.ts
+++ b/lib/id3v1/ID3v1Parser.ts
@@ -93,9 +93,12 @@ const Iid3v1Token: IGetToken<IId3v1Header | null> = {
 
 class Id3v1StringType implements IGetToken<string | undefined> {
 
+  public len: number;
+
   private stringType;
 
-  constructor(public len: number) {
+  constructor(len: number) {
+    this.len = len;
     this.stringType = new StringType(len, 'latin1');
   }
 

--- a/lib/id3v2/FrameParser.ts
+++ b/lib/id3v2/FrameParser.ts
@@ -100,13 +100,18 @@ function parseGenreCode(code: string): string | undefined{
 }
 
 export class FrameParser {
+  private major: ID3v2MajorVersion;
+
+  private warningCollector: IWarningCollector;
 
   /**
    * Create id3v2 frame parser
    * @param major - Major version, e.g. (4) for  id3v2.4
    * @param warningCollector - Used to collect decode issue
    */
-  constructor(private major: ID3v2MajorVersion, private warningCollector: IWarningCollector) {
+  constructor(major: ID3v2MajorVersion, warningCollector: IWarningCollector) {
+    this.major = major;
+    this.warningCollector = warningCollector;
   }
 
   public readData(uint8Array: Uint8Array, type: string, includeCovers: boolean) {

--- a/lib/id3v2/FrameParser.ts
+++ b/lib/id3v2/FrameParser.ts
@@ -210,7 +210,7 @@ export class FrameParser {
 
           pic.format = FrameParser.fixPictureMimeType(pic.format);
 
-          pic.type = AttachedPictureType[uint8Array[offset]];
+          pic.type = AttachedPictureType[uint8Array[offset] as keyof typeof AttachedPictureType];
           offset += 1;
 
           fzero = util.findZero(uint8Array, offset, length, encoding);

--- a/lib/id3v2/ID3v2Token.ts
+++ b/lib/id3v2/ID3v2Token.ts
@@ -7,28 +7,28 @@ import * as util from '../common/Util.js';
  * The picture type according to the ID3v2 APIC frame
  * Ref: http://id3.org/id3v2.3.0#Attached_picture
  */
-export enum AttachedPictureType {
-  'Other' = 0,
-  "32x32 pixels 'file icon' (PNG only)" = 1,
-  'Other file icon' = 2,
-  'Cover (front)' = 3,
-  'Cover (back)' = 4,
-  'Leaflet page' = 5,
-  'Media (e.g. label side of CD)' = 6,
-  'Lead artist/lead performer/soloist' = 7,
-  'Artist/performer' = 8,
-  'Conductor' = 9,
-  'Band/Orchestra' = 10,
-  'Composer' = 11,
-  'Lyricist/text writer' = 12,
-  'Recording Location' = 13,
-  'During recording' = 14,
-  'During performance' = 15,
-  'Movie/video screen capture' = 16,
-  'A bright coloured fish' = 17,
-  'Illustration' = 18,
-  'Band/artist logotype' = 19,
-  'Publisher/Studio logotype' = 20
+export const AttachedPictureType = {
+  0: 'Other',
+  1: "32x32 pixels 'file icon' (PNG only)",
+  2: 'Other file icon',
+  3: 'Cover (front)',
+  4: 'Cover (back)',
+  5: 'Leaflet page',
+  6: 'Media (e.g. label side of CD)',
+  7: 'Lead artist/lead performer/soloist',
+  8: 'Artist/performer',
+  9: 'Conductor',
+  10: 'Band/Orchestra',
+  11: 'Composer',
+  12: 'Lyricist/text writer',
+  13: 'Recording Location',
+  14: 'During recording',
+  15: 'During performance',
+  16: 'Movie/video screen capture',
+  17: 'A bright coloured fish',
+  18: 'Illustration',
+  19: 'Band/artist logotype',
+  20: 'Publisher/Studio logotype'
 }
 
 export type ID3v2MajorVersion = 2 | 3 | 4;
@@ -46,21 +46,23 @@ export interface IExtendedHeader {
 /**
  * https://id3.org/id3v2.3.0#Synchronised_lyrics.2Ftext
  */
-export enum LyricsContentType {
-  other = 0,
-  lyrics = 1,
-  text = 2,
-  movement_part = 3,
-  events = 4,
-  chord = 5,
-  trivia_pop = 6
-}
+export const LyricsContentType = {
+  other: 0,
+  lyrics: 1,
+  text: 2,
+  movement_part: 3,
+  events: 4,
+  chord: 5,
+  trivia_pop: 6,
+};
+export type LyricsContentType = typeof LyricsContentType[keyof typeof LyricsContentType];
 
-export enum TimestampFormat {
-  notSynchronized0 = 0,
-  mpegFrameNumber = 1,
-  milliseconds = 2
-}
+export const TimestampFormat = {
+  notSynchronized0: 0,
+  mpegFrameNumber: 1,
+  milliseconds: 2
+};
+export type TimestampFormat = typeof TimestampFormat[keyof typeof TimestampFormat];
 
 /**
  * 28 bits (representing up to 256MB) integer, the msb is 0 to avoid 'false syncsignals'.

--- a/lib/matroska/types.ts
+++ b/lib/matroska/types.ts
@@ -91,33 +91,43 @@ export interface ISimpleTag {
   default?: boolean;
 }
 
-export enum TargetType {
-  shot = 10,
-  scene = 20,
-  track = 30,
-  part = 40,
-  album = 50,
-  edition = 60,
-  collection = 70
+export const TargetType = {
+  10: 'shot',
+  20: 'scene',
+  30: 'track',
+  40: 'part',
+  50: 'album',
+  60: 'edition',
+  70: 'collection'
 }
 
-export enum TrackType {
-  video = 0x01,
-  audio = 0x02,
-  complex = 0x03,
-  logo = 0x04,
-  subtitle= 0x11,
-  button = 0x12,
-  control = 0x20
-}
+export const TrackType = {
+  video: 0x01,
+  audio: 0x02,
+  complex: 0x03,
+  logo: 0x04,
+  subtitle: 0x11,
+  button: 0x12,
+  control: 0x20
+};
+export type TrackType = typeof TrackType[keyof typeof TrackType];
+export type TrackTypeKey = keyof typeof TrackType;
 
-export type TrackTypeKey = keyof TrackType;
+export const TrackTypeValueToKeyMap: Record<TrackType, TrackTypeKey> = {
+  [TrackType.video]: 'video',
+  [TrackType.audio]: 'audio',
+  [TrackType.complex]: 'complex',
+  [TrackType.logo]: 'logo',
+  [TrackType.subtitle]: 'subtitle',
+  [TrackType.button]: 'button',
+  [TrackType.control]: 'control'
+}
 
 export interface ITarget {
   trackUID?: Uint8Array;
   chapterUID?: Uint8Array;
   attachmentUID?: Uint8Array;
-  targetTypeValue?: TargetType;
+  targetTypeValue?: keyof typeof TargetType;
   targetType?: string;
 }
 

--- a/lib/mp4/Atom.ts
+++ b/lib/mp4/Atom.ts
@@ -30,7 +30,14 @@ export class Atom {
   public readonly children: Atom[];
   public readonly atomPath: string;
 
-  public constructor(public readonly header: AtomToken.IAtomHeader, public extended: boolean, public readonly parent: Atom | null) {
+  public readonly header: AtomToken.IAtomHeader;
+  public extended: boolean;
+  public readonly parent: Atom | null;
+
+  public constructor(header: AtomToken.IAtomHeader, extended: boolean, parent: Atom | null) {
+    this.header = header;
+    this.extended = extended;
+    this.parent = parent;
     this.children = [];
     this.atomPath = (this.parent ? `${this.parent.atomPath}.` : '') + this.header.name;
   }

--- a/lib/mp4/AtomToken.ts
+++ b/lib/mp4/AtomToken.ts
@@ -204,18 +204,22 @@ export const mhdr: IGetToken<IMovieHeaderAtom> = {
  * Issue: https://github.com/Borewit/music-metadata/issues/120
  */
 export abstract class FixedLengthAtom {
+  public len: number;
+
   /**
    *
    * @param {number} len Length as specified in the size field
    * @param {number} expLen Total length of sum of specified fields in the standard
    * @param atomId Atom ID
    */
-  protected constructor(public len: number, expLen: number, atomId: string) {
+  protected constructor(len: number, expLen: number, atomId: string) {
     if (len < expLen) {
       throw new Mp4ContentError(`Atom ${atomId} expected to be ${expLen}, but specifies ${len} bytes long.`);
     }if (len > expLen) {
       debug(`Warning: atom ${atomId} expected to be ${expLen}, but was actually ${len} bytes long.`);
     }
+
+    this.len = len;
   }
 }
 
@@ -252,8 +256,7 @@ const SecondsSinceMacEpoch: IGetToken<Date> = {
  * - https://wiki.multimedia.cx/index.php/QuickTime_container#mdhd
  */
 export class MdhdAtom extends FixedLengthAtom implements IGetToken<IAtomMdhd> {
-
-  public constructor(public len: number) {
+  public constructor(len: number) {
     super(len, 24, 'mdhd');
   }
 
@@ -276,7 +279,7 @@ export class MdhdAtom extends FixedLengthAtom implements IGetToken<IAtomMdhd> {
  */
 export class MvhdAtom extends FixedLengthAtom implements IGetToken<IAtomMvhd> {
 
-  public constructor(public len: number) {
+  public constructor(len: number) {
     super(len, 100, 'mvhd');
   }
 
@@ -335,8 +338,10 @@ export interface IDataAtom {
  * Data Atom Structure
  */
 export class DataAtom implements IGetToken<IDataAtom> {
+  public len: number;
 
-  public constructor(public len: number) {
+  public constructor(len: number) {
+    this.len = len;
   }
 
   public get(buf: Uint8Array, off: number): IDataAtom {
@@ -368,8 +373,10 @@ export interface INameAtom extends IVersionAndFlags {
  * Ref: https://developer.apple.com/library/content/documentation/QuickTime/QTFF/Metadata/Metadata.html#//apple_ref/doc/uid/TP40000939-CH1-SW31
  */
 export class NameAtom implements IGetToken<INameAtom> {
+  public len: number;
 
-  public constructor(public len: number) {
+  public constructor(len: number) {
+    this.len = len;
   }
 
   public get(buf: Uint8Array, off: number): INameAtom {
@@ -439,8 +446,10 @@ export interface ITrackHeaderAtom extends IVersionAndFlags {
  * Ref: https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-25550
  */
 export class TrackHeaderAtom implements IGetToken<ITrackHeaderAtom> {
+  public len: number;
 
-  public constructor(public len: number) {
+  public constructor(len: number) {
+    this.len = len;
   }
 
   public get(buf: Uint8Array, off: number): ITrackHeaderAtom {
@@ -502,8 +511,10 @@ export interface IAtomStsd {
  * Ref: https://developer.apple.com/documentation/quicktime-file-format/sample_description_atom
  */
 class SampleDescriptionTable implements IGetToken<ISampleDescription> {
+  public len: number;
 
-  public constructor(public len: number) {
+  public constructor(len: number) {
+    this.len = len;
   }
 
   public get(buf: Uint8Array, off: number): ISampleDescription {
@@ -521,8 +532,10 @@ class SampleDescriptionTable implements IGetToken<ISampleDescription> {
  * Ref: https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-25691
  */
 export class StsdAtom implements IGetToken<IAtomStsd> {
+  public len: number;
 
-  public constructor(public len: number) {
+  public constructor(len: number) {
+    this.len = len;
   }
 
   public get(buf: Uint8Array, off: number): IAtomStsd {
@@ -610,8 +623,12 @@ export interface ITableAtom<T> extends IVersionAndFlags {
 }
 
 class SimpleTableAtom<T> implements IGetToken<ITableAtom<T>> {
+  public len: number;
+  private token: IGetToken<T>
 
-  public constructor(public len: number, private token: IGetToken<T>) {
+  public constructor(len: number, token: IGetToken<T>) {
+    this.len = len;
+    this.token = token;
   }
 
   public get(buf: Uint8Array, off: number): ITableAtom<T> {
@@ -650,7 +667,7 @@ export const TimeToSampleToken: IGetToken<ITimeToSampleToken> = {
  * Ref: https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-25696
  */
 export class SttsAtom extends SimpleTableAtom<ITimeToSampleToken> {
-  public constructor(public len: number) {
+  public constructor(len: number) {
     super(len, TimeToSampleToken);
   }
 }
@@ -682,7 +699,7 @@ export const SampleToChunkToken: IGetToken<ISampleToChunk> = {
  * Ref: https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-25706
  */
 export class StscAtom extends SimpleTableAtom<ISampleToChunk> {
-  public constructor(public len: number) {
+  public constructor(len: number) {
     super(len, SampleToChunkToken);
   }
 }
@@ -699,8 +716,10 @@ export interface IStszAtom extends ITableAtom<number> {
  * Ref: https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-25710
  */
 export class StszAtom implements IGetToken<IStszAtom> {
+  public len: number;
 
-  public constructor(public len: number) {
+  public constructor(len: number) {
+    this.len = len;
   }
 
   public get(buf: Uint8Array, off: number): IStszAtom {
@@ -722,8 +741,11 @@ export class StszAtom implements IGetToken<IStszAtom> {
  * Ref: https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-25715
  */
 export class StcoAtom extends SimpleTableAtom<number> {
-  public constructor(public len: number) {
+  public len: number;
+
+  public constructor(len: number) {
     super(len, Token.INT32_BE);
+    this.len = len;
   }
 }
 
@@ -731,8 +753,10 @@ export class StcoAtom extends SimpleTableAtom<number> {
  * Token used to decode text-track from 'mdat' atom (raw data stream)
  */
 export class ChapterText implements IGetToken<string> {
+  public len: number;
 
-  public constructor(public len: number) {
+  public constructor(len: number) {
+    this.len = len;
   }
 
   public get(buf: Uint8Array, off: number): string {

--- a/lib/mpeg/ReplayGainDataFormat.ts
+++ b/lib/mpeg/ReplayGainDataFormat.ts
@@ -10,46 +10,48 @@ export interface IReplayGain {
 /**
  * https://github.com/Borewit/music-metadata/wiki/Replay-Gain-Data-Format#name-code
  */
-enum NameCode {
+const NameCode = {
   /**
    * not set
    */
-  not_set = 0,
+  not_set: 0,
   /**
    * Radio Gain Adjustment
    */
-  radio = 1 ,
+  radio: 1,
   /**
    * Audiophile Gain Adjustment
    */
-  audiophile = 2
-}
+  audiophile: 2
+};
+type NameCode = typeof NameCode[keyof typeof NameCode];
 
 /**
  * https://github.com/Borewit/music-metadata/wiki/Replay-Gain-Data-Format#originator-code
  */
-enum ReplayGainOriginator {
+const ReplayGainOriginator ={
   /**
    * Replay Gain unspecified
    */
-  unspecified = 0,
+  unspecified: 0,
   /**
    * Replay Gain pre-set by artist/producer/mastering engineer
    */
-  engineer = 1,
+  engineer: 1,
   /**
    * Replay Gain set by user
    */
-  user = 2,
+  user: 2,
   /**
    * Replay Gain determined automatically, as described on this site
    */
-  automatic = 3,
+  automatic: 3,
   /**
    * Set by simple RMS average
    */
-  rms_average = 4
+  rms_average: 4
 }
+type ReplayGainOriginator = typeof ReplayGainOriginator[keyof typeof ReplayGainOriginator];
 
 /**
  * Replay Gain Data Format

--- a/lib/musepack/sv7/BitReader.ts
+++ b/lib/musepack/sv7/BitReader.ts
@@ -5,8 +5,10 @@ export class BitReader {
 
   public pos = 0;
   private dword: number | null = null;
+  private tokenizer: ITokenizer;
 
-  public constructor(private tokenizer: ITokenizer) {
+  public constructor(tokenizer: ITokenizer) {
+    this.tokenizer = tokenizer;
   }
 
   /**

--- a/lib/musepack/sv8/MpcSv8Parser.ts
+++ b/lib/musepack/sv8/MpcSv8Parser.ts
@@ -60,6 +60,7 @@ export class MpcSv8Parser extends BasicParser {
         default:
           throw new MusepackContentError(`Unexpected header: ${header.key}`);
       }
+    // biome-ignore lint/correctness/noConstantCondition: break is handled in the switch statement
     } while (true);
   }
 }

--- a/lib/musepack/sv8/StreamVersion8.ts
+++ b/lib/musepack/sv8/StreamVersion8.ts
@@ -84,8 +84,17 @@ interface IStreamHeader extends IStreamHeader1, IStreamHeader3 {
 }
 
 export class StreamReader {
+  private _tokenizer: ITokenizer;
 
-  public constructor(private tokenizer: ITokenizer) {
+  public get tokenizer(): ITokenizer {
+    return this._tokenizer;
+  }
+  public set tokenizer(value: ITokenizer) {
+    this._tokenizer = value;
+  }
+
+  public constructor(_tokenizer: ITokenizer) {
+    this._tokenizer = _tokenizer;
   }
 
   public async readPacketHeader(): Promise<IPacketHeader> {

--- a/lib/ogg/opus/Opus.ts
+++ b/lib/ogg/opus/Opus.ts
@@ -49,11 +49,14 @@ export class OpusContentError extends makeUnexpectedFileContentError('Opus'){
  * Ref: https://wiki.xiph.org/OggOpus#ID_Header
  */
 export class IdHeader implements IGetToken<IIdHeader> {
+  public len: number;
 
-  constructor(public len: number) {
+  constructor(len: number) {
     if (len < 19) {
       throw new OpusContentError('ID-header-page 0 should be at least 19 bytes long');
     }
+
+    this.len = len;
   }
 
   public get(buf: Uint8Array, off: number): IIdHeader {

--- a/lib/ogg/opus/OpusParser.ts
+++ b/lib/ogg/opus/OpusParser.ts
@@ -18,9 +18,11 @@ export class OpusParser extends VorbisParser {
 
   private idHeader: Opus.IIdHeader = null as unknown as Opus.IIdHeader;
   private lastPos = -1;
+  private tokenizer: ITokenizer;
 
-  constructor(metadata: INativeMetadataCollector, options: IOptions, private tokenizer: ITokenizer) {
+  constructor(metadata: INativeMetadataCollector, options: IOptions, tokenizer: ITokenizer) {
     super(metadata, options);
+    this.tokenizer = tokenizer;
   }
 
   /**

--- a/lib/ogg/speex/SpeexParser.ts
+++ b/lib/ogg/speex/SpeexParser.ts
@@ -18,8 +18,11 @@ const debug = initDebug('music-metadata:parser:ogg:speex');
  */
 export class SpeexParser extends VorbisParser {
 
-  constructor(metadata: INativeMetadataCollector, options: IOptions, private tokenizer: ITokenizer) {
+  private tokenizer: ITokenizer;
+
+  constructor(metadata: INativeMetadataCollector, options: IOptions, tokenizer: ITokenizer) {
     super(metadata, options);
+    this.tokenizer = tokenizer;
   }
 
   /**

--- a/lib/ogg/theora/TheoraParser.ts
+++ b/lib/ogg/theora/TheoraParser.ts
@@ -14,7 +14,13 @@ const debug = initDebug('music-metadata:parser:ogg:theora');
  */
 export class TheoraParser implements Ogg.IPageConsumer {
 
-  constructor(private metadata: INativeMetadataCollector, options: IOptions, private tokenizer: ITokenizer) {
+  private metadata: INativeMetadataCollector;
+
+  private tokenizer: ITokenizer
+
+  constructor(metadata: INativeMetadataCollector, options: IOptions, tokenizer: ITokenizer) {
+    this.metadata = metadata;
+    this.tokenizer = tokenizer;
   }
 
   /**

--- a/lib/ogg/vorbis/Vorbis.ts
+++ b/lib/ogg/vorbis/Vorbis.ts
@@ -42,7 +42,10 @@ export class VorbisPictureToken implements IGetToken<IVorbisPicture> {
     return pic.get(buffer, 0);
   }
 
-  constructor(public len: number) {
+  public len: number;
+
+  constructor(len: number) {
+    this.len = len;
   }
 
   public get(buffer: Uint8Array, offset: number): IVorbisPicture {

--- a/lib/ogg/vorbis/Vorbis.ts
+++ b/lib/ogg/vorbis/Vorbis.ts
@@ -47,7 +47,7 @@ export class VorbisPictureToken implements IGetToken<IVorbisPicture> {
 
   public get(buffer: Uint8Array, offset: number): IVorbisPicture {
 
-    const type = AttachedPictureType[Token.UINT32_BE.get(buffer, offset)];
+    const type = AttachedPictureType[Token.UINT32_BE.get(buffer, offset) as keyof typeof AttachedPictureType];
 
     offset += 4;
     const mimeLen = Token.UINT32_BE.get(buffer, offset);

--- a/lib/ogg/vorbis/VorbisDecoder.ts
+++ b/lib/ogg/vorbis/VorbisDecoder.ts
@@ -1,8 +1,13 @@
 import * as Token from 'token-types';
 
 export class VorbisDecoder {
+  private readonly data: Uint8Array;
 
-  constructor(private readonly data: Uint8Array, private offset: number) {
+  private offset: number;
+
+  constructor(data: Uint8Array, offset: number) {
+    this.data = data;
+    this.offset = offset;
   }
 
   public readInt32(): number {

--- a/lib/ogg/vorbis/VorbisParser.ts
+++ b/lib/ogg/vorbis/VorbisParser.ts
@@ -22,7 +22,13 @@ export class VorbisParser implements IPageConsumer {
 
   private pageSegments: Uint8Array[] = [];
 
-  constructor(protected metadata: INativeMetadataCollector, protected options: IOptions) {
+  protected metadata: INativeMetadataCollector;
+
+  protected options: IOptions;
+
+  constructor(metadata: INativeMetadataCollector, options: IOptions) {
+    this.metadata = metadata;
+    this.options = options;
   }
 
   /**

--- a/lib/riff/RiffChunk.ts
+++ b/lib/riff/RiffChunk.ts
@@ -27,7 +27,10 @@ export class ListInfoTagValue implements IGetToken<string> {
 
   public len: number;
 
-  public constructor(private tagHeader: IChunkHeader) {
+  private tagHeader: IChunkHeader;
+
+  public constructor(tagHeader: IChunkHeader) {
+    this.tagHeader = tagHeader;
     this.len = tagHeader.chunkSize;
     this.len += this.len & 1; // if it is an odd length, round up to even
   }

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -3,7 +3,7 @@ import type { IFooter } from './apev2/APEv2Token.js';
 import type { TrackType } from './matroska/types.js';
 import type { LyricsContentType, TimestampFormat } from './id3v2/ID3v2Token.js';
 
-export { TrackType } from './matroska/types.js';
+export { TrackType, TrackTypeValueToKeyMap } from './matroska/types.js';
 export { LyricsContentType, TimestampFormat } from './id3v2/ID3v2Token.js';
 
 export type AnyTagValue = unknown;

--- a/lib/wav/WaveChunk.ts
+++ b/lib/wav/WaveChunk.ts
@@ -9,23 +9,40 @@ export class WaveContentError extends makeUnexpectedFileContentError('Wave'){
 /**
  * Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/dd317599(v=vs.85).aspx
  */
-export enum WaveFormat {
-  PCM = 0x0001,
+export const WaveFormat = {
+  PCM: 0x0001,
   // MPEG-4 and AAC Audio Types
-  ADPCM = 0x0002,
-  IEEE_FLOAT = 0x0003,
-  MPEG_ADTS_AAC = 0x1600,
-  MPEG_LOAS = 0x1602,
-  RAW_AAC1 = 0x00FF,
+  ADPCM: 0x0002,
+  IEEE_FLOAT: 0x0003,
+  MPEG_ADTS_AAC: 0x1600,
+  MPEG_LOAS: 0x1602,
+  RAW_AAC1: 0x00FF,
   // Dolby Audio Types
-  DOLBY_AC3_SPDIF = 0x0092,
-  DVM = 0x2000,
-  RAW_SPORT = 0x0240,
-  ESST_AC3 = 0x0241,
-  DRM = 0x0009,
-  DTS2 = 0x2001,
-  MPEG = 0x0050
-}
+  DOLBY_AC3_SPDIF: 0x0092,
+  DVM: 0x2000,
+  RAW_SPORT: 0x0240,
+  ESST_AC3: 0x0241,
+  DRM: 0x0009,
+  DTS2: 0x2001,
+  MPEG: 0x0050
+};
+export type WaveFormat = typeof WaveFormat[keyof typeof WaveFormat];
+
+export const WaveFormatNameMap = {
+  [WaveFormat.PCM]: 'PCM',
+  [WaveFormat.ADPCM]: 'ADPCM',
+  [WaveFormat.IEEE_FLOAT]: 'IEEE_FLOAT',
+  [WaveFormat.MPEG_ADTS_AAC]: 'MPEG_ADTS_AAC',
+  [WaveFormat.MPEG_LOAS]: 'MPEG_LOAS',
+  [WaveFormat.RAW_AAC1]: 'RAW_AAC1',
+  [WaveFormat.DOLBY_AC3_SPDIF]: 'DOLBY_AC3_SPDIF',
+  [WaveFormat.DVM]: 'DVM',
+  [WaveFormat.RAW_SPORT]: 'RAW_SPORT',
+  [WaveFormat.ESST_AC3]: 'ESST_AC3',
+  [WaveFormat.DRM]: 'DRM',
+  [WaveFormat.DTS2]: 'DTS2',
+  [WaveFormat.MPEG]: 'MPEG'
+};
 
 /**
  * "fmt"  sub-chunk describes the sound data's format

--- a/lib/wav/WaveParser.ts
+++ b/lib/wav/WaveParser.ts
@@ -80,7 +80,7 @@ export class WaveParser extends BasicParser {
         case 'fmt ': { // The Util Chunk, non-PCM Formats
           const fmt = await this.tokenizer.readToken<WaveChunk.IWaveFormat>(new WaveChunk.Format(header));
 
-          let subFormat = WaveChunk.WaveFormat[fmt.wFormatTag];
+          let subFormat = WaveChunk.WaveFormatNameMap[fmt.wFormatTag];
           if (!subFormat) {
             debug(`WAVE/non-PCM format=${fmt.wFormatTag}`);
             subFormat = `non-PCM (${fmt.wFormatTag})`;

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "build": "yarn run clean && yarn compile && yarn run doc-gen",
     "test-coverage": "c8 yarn run test",
     "send-codacy": "c8 report --reporter=text-lcov | codacy-coverage",
-    "doc-gen": "yarn node doc-gen/gen.js"
+    "doc-gen": "yarn node doc-gen/gen.js",
+    "typecheck": "tsc --project ./lib/tsconfig.json --noEmit && tsc --project ./test/tsconfig.json --noEmit"
   },
   "dependencies": {
     "@tokenizer/token": "^0.3.0",

--- a/test/util.ts
+++ b/test/util.ts
@@ -14,9 +14,11 @@ const dirname = path.dirname(filename);
  * A mock readable-stream, using string to read from
  */
 export class SourceStream extends Readable {
+  private buf: Uint8Array;
 
-  constructor(private buf: Uint8Array) {
+  constructor(buf: Uint8Array) {
     super();
+    this.buf = buf;
   }
 
   public _read() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node16",
     "target": "ES2020",
     "esModuleInterop": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "erasableSyntaxOnly": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "ES2020",
     "esModuleInterop": true,
     "baseUrl": ".",
-    "erasableSyntaxOnly": false
+    "erasableSyntaxOnly": true,
+    "libReplacement": false,
   }
 }


### PR DESCRIPTION
I was looking into my application bundle and one easy way to reduce stood out enum usage. There are [few reasons](https://www.totaltypescript.com/why-i-dont-like-typescript-enums) why you should not use them, but most important for libraries is their compiled size. This should be small perf win for bundle size.

- Add typecheck command.
- Enable `erasableSyntaxOnly` flag in typescript so no TS runtime features are used.
- Replace enum usage with mapped object instead. I did not mark them `as const` because a lot of places expected number instead of a specific value. This could be improved in the future to be more type safe.
- Replace constructor modifiers with explicit assignments.