### PR TITLE
refactor: parser load fn returns class instead of instance

### DIFF
--- a/lib/ParserFactory.ts
+++ b/lib/ParserFactory.ts
@@ -34,9 +34,9 @@ export interface IParserLoader {
   parserType: ParserType;
 
   /**
-   * Lazy load the parser
+   * Lazy load the parser implementation class.
    */
-  load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser>
+  load(): Promise<new (metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions) => ITokenParser>;
 }
 
 export interface ITokenParser {
@@ -126,7 +126,8 @@ export class ParserFactory {
     // Parser found, execute parser
     debug(`Loading ${parserLoader.parserType} parser...`);
     const metadata = new MetadataCollector(opts);
-    const parser = await parserLoader.load(metadata, tokenizer, opts ?? {});
+    const ParserImpl = await parserLoader.load();
+    const parser = new ParserImpl(metadata, tokenizer, opts ?? {});
     debug(`Parser ${parserLoader.parserType} loaded`);
     await parser.parse();
     return metadata.toCommonMetadata();

--- a/lib/aiff/AiffLoader.ts
+++ b/lib/aiff/AiffLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const aiffParserLoader: IParserLoader = {
   parserType: 'aiff',
   extensions: ['.aif', 'aiff', 'aifc'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./AiffParser.js')).AIFFParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./AiffParser.js')).AIFFParser;
   }
 };

--- a/lib/apev2/Apev2Loader.ts
+++ b/lib/apev2/Apev2Loader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const apeParserLoader: IParserLoader = {
   parserType: 'apev2',
   extensions: ['.ape'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./APEv2Parser.js')).APEv2Parser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./APEv2Parser.js')).APEv2Parser
   }
 };

--- a/lib/asf/AsfLoader.ts
+++ b/lib/asf/AsfLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const asfParserLoader: IParserLoader = {
   parserType: 'asf',
   extensions: ['.asf'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./AsfParser.js')).AsfParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./AsfParser.js')).AsfParser;
   }
 };

--- a/lib/dsdiff/DsdiffLoader.ts
+++ b/lib/dsdiff/DsdiffLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const dsdiffParserLoader: IParserLoader = {
   parserType: 'dsdiff',
   extensions: ['.dff'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./DsdiffParser.js')).DsdiffParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./DsdiffParser.js')).DsdiffParser
   }
 };

--- a/lib/dsf/DsfLoader.ts
+++ b/lib/dsf/DsfLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const dsfParserLoader: IParserLoader = {
   parserType: 'dsf',
   extensions: ['.dsf'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./DsfParser.js')).DsfParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./DsfParser.js')).DsfParser
   }
 };

--- a/lib/flac/FlacLoader.ts
+++ b/lib/flac/FlacLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const flacParserLoader: IParserLoader = {
   parserType: 'flac',
   extensions: ['.flac'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./FlacParser.js')).FlacParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./FlacParser.js')).FlacParser
   }
 };

--- a/lib/matroska/MatroskaLoader.ts
+++ b/lib/matroska/MatroskaLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const matroskaParserLoader: IParserLoader = {
   parserType: 'matroska',
   extensions: ['.mka', '.mkv', '.mk3d', '.mks', 'webm'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./MatroskaParser.js')).MatroskaParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./MatroskaParser.js')).MatroskaParser
   }
 };

--- a/lib/mp4/Mp4Loader.ts
+++ b/lib/mp4/Mp4Loader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const mp4ParserLoader: IParserLoader = {
   parserType: 'mp4',
   extensions: ['.mp4', '.m4a', '.m4b', '.m4pa', 'm4v', 'm4r', '3gp'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./MP4Parser.js')).MP4Parser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./MP4Parser.js')).MP4Parser
   }
 };

--- a/lib/mpeg/MpegLoader.ts
+++ b/lib/mpeg/MpegLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const mpegParserLoader: IParserLoader = {
   parserType: 'mpeg',
   extensions: ['.mp2', '.mp3', '.m2a', '.aac', 'aacp'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./MpegParser.js')).MpegParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./MpegParser.js')).MpegParser;
   }
 };

--- a/lib/musepack/MusepackLoader.ts
+++ b/lib/musepack/MusepackLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const musepackParserLoader: IParserLoader = {
   parserType: 'musepack',
   extensions: ['.mpc'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./MusepackParser.js')).MusepackParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./MusepackParser.js')).MusepackParser;
   }
 };

--- a/lib/ogg/OggLoader.ts
+++ b/lib/ogg/OggLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader, } from '../ParserFactory.js';
 
 export const oggParserLoader: IParserLoader = {
   parserType: 'ogg',
   extensions: ['.ogg', '.ogv', '.oga', '.ogm', '.ogx', '.opus', '.spx'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./OggParser.js')).OggParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./OggParser.js')).OggParser
   }
 };

--- a/lib/wav/WaveLoader.ts
+++ b/lib/wav/WaveLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const riffParserLoader: IParserLoader = {
   parserType: 'riff',
   extensions: ['.wav', 'wave', '.bwf'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./WaveParser.js')).WaveParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./WaveParser.js')).WaveParser
   }
 };

--- a/lib/wavpack/WavPackLoader.ts
+++ b/lib/wavpack/WavPackLoader.ts
@@ -1,12 +1,9 @@
-import type { IParserLoader, ITokenParser } from '../ParserFactory.js';
-import type { INativeMetadataCollector } from '../common/MetadataCollector.js';
-import type { ITokenizer } from 'strtok3';
-import type { IOptions } from '../type.js';
+import type { IParserLoader } from '../ParserFactory.js';
 
 export const wavpackParserLoader: IParserLoader = {
   parserType: 'wavpack',
   extensions: ['.wv', '.wvp'],
-  async load(metadata: INativeMetadataCollector, tokenizer: ITokenizer, options: IOptions): Promise<ITokenParser> {
-    return new (await import('./WavPackParser.js')).WavPackParser(metadata, tokenizer, options);
+  async load() {
+    return (await import('./WavPackParser.js')).WavPackParser;
   }
 };


### PR DESCRIPTION
Right now every parser loader creates new instance inside `load` function, to do that we need to pass constructor arguments inside loader function, which adds repetitive code and increases bundle size slightly. Instead this PR makes it so `load` function returns implementation class only.
