### PR TITLE
feat: add sideEffects false to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "url": "https://buymeacoffee.com/borewit"
     }
   ],
+  "sideEffects": false,  
   "type": "module",
   "exports": {
     "node": {


### PR DESCRIPTION
Setting `sideEffects: false` means bundler can safely remove file if no imports are used from it allowing for better tree-shaking.
 
More info here:
 https://webpack.js.org/guides/tree-shaking/
 https://github.com/evanw/esbuild/issues/1241#issuecomment-831130652

