### PR TITLE
Document `node16` or `nodenext` to enable dynamic import

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,9 +788,10 @@ For older Node.js version < 22, you need to dynamically import **music-metadata*
 })();
 ```
 
-For CommonJS TypeScript projects, using a Node.js version < 22, you can use [load-esm](https://github.com/Borewit/load-esm):
+For CommonJS TypeScript projects, I recommend to avoid using `commonjs` for the TypeScript compiler `module` option, 
+and either use `node16` or `nodenext`, which enable utilizing [dynamic import](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import).
 
-This method shall has replaced the embedded CJS loader function: `loadMusicMetadata()`.
+If you do want to use the classic `commonjs` option, this is how you can get the _dynamic import_ to work.
 
 ```js
 import {loadEsm} from 'load-esm';
@@ -800,6 +801,8 @@ import {loadEsm} from 'load-esm';
   const mm = await loadEsm<typeof import('music-metadata')>('music-metadata');
 })();
 ```
+
+When you use Node.js version ≥ 22, which supports loading ESM modules via require, this compensates for that issue.
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
- Updated instructions for CommonJS TypeScript projects to discourage using the "commonjs" module option.
- Provided guidance on leveraging dynamic import when using the classic "commonjs" approach.
- Added a note about handling ESM module loading for Node.js versions ≥ 22.