### PR TITLE
Be able to auto-detect MPEG frames, starting at slightly incorrect offset

### DIFF
--- a/lib/ParserFactory.ts
+++ b/lib/ParserFactory.ts
@@ -114,7 +114,7 @@ export class ParserFactory {
         debug('Guess parser on content...');
         await tokenizer.peekBuffer(buf, {mayBeLess: true});
 
-        const guessedType = await fileTypeFromBuffer(buf);
+        const guessedType = await fileTypeFromBuffer(buf, {mpegOffsetTolerance: 10});
         if (!guessedType || !guessedType.mime) {
           throw new CouldNotDetermineFileTypeError('Failed to determine audio format');
         }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@tokenizer/token": "^0.3.0",
     "content-type": "^1.0.5",
     "debug": "^4.4.1",
-    "file-type": "^20.5.0",
+    "file-type": "^21.0.0",
     "media-typer": "^1.1.0",
     "strtok3": "^10.2.2",
     "token-types": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,7 +335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tokenizer/inflate@npm:^0.2.6":
+"@tokenizer/inflate@npm:^0.2.7":
   version: 0.2.7
   resolution: "@tokenizer/inflate@npm:0.2.7"
   dependencies:
@@ -1224,15 +1224,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-type@npm:^20.5.0":
-  version: 20.5.0
-  resolution: "file-type@npm:20.5.0"
+"file-type@npm:^21.0.0":
+  version: 21.0.0
+  resolution: "file-type@npm:21.0.0"
   dependencies:
-    "@tokenizer/inflate": "npm:^0.2.6"
-    strtok3: "npm:^10.2.0"
+    "@tokenizer/inflate": "npm:^0.2.7"
+    strtok3: "npm:^10.2.2"
     token-types: "npm:^6.0.0"
     uint8array-extras: "npm:^1.4.0"
-  checksum: 10c0/9b13d7e4eca79752008f036712a42df78393f05b88b9013c5754b04d3eb90b051cb692836a04acf7d2c696cb9f28077ddf8ebd6830175807f14fddf837d63be3
+  checksum: 10c0/ee6b0bb5771ad154e236bb77b5c00907743fef3637c3825713c1d6913377d3d969ebba4a6f0aa854b8231552e2c1bd0387229fe67394dc3d08a01819c7d107b1
   languageName: node
   linkType: hard
 
@@ -2344,7 +2344,7 @@ __metadata:
     content-type: "npm:^1.0.5"
     debug: "npm:^4.4.1"
     del-cli: "npm:^6.0.0"
-    file-type: "npm:^20.5.0"
+    file-type: "npm:^21.0.0"
     media-typer: "npm:^1.1.0"
     mime: "npm:^4.0.7"
     mocha: "npm:^11.4.0"
@@ -3192,7 +3192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strtok3@npm:^10.2.0, strtok3@npm:^10.2.2":
+"strtok3@npm:^10.2.2":
   version: 10.2.2
   resolution: "strtok3@npm:10.2.2"
   dependencies:


### PR DESCRIPTION
Changes:
- Be able to auto-detect MPEG frames, starting at slightly incorrect offset.
- Update file-type to 21.0.0.