### PR TITLE
Update dependency strtok3 v10.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,6 @@ graph TD;
     MMP-->UAE
     FTN("file-type (Node.js entry point)")-->FTP
     FTP("file-type (primary entry point)")-->S
-    S(strtok3)-->P(peek-readable)
     S(strtok3)-->TO("@tokenizer/token")
     TY(token-types)-->TO
     TY-->IE("ieee754")
@@ -771,7 +770,6 @@ Dependency list:
 - [token-types](https://github.com/Borewit/token-types)
 - [file-type](https://github.com/sindresorhus/file-type)
 - [@tokenizer-token](https://github.com/Borewit/tokenizer-token)
-- [peek-readable](https://github.com/Borewit/peek-readable)
 
 ## CommonJS backward compatibility
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "debug": "^4.4.1",
     "file-type": "^21.0.0",
     "media-typer": "^1.1.0",
-    "strtok3": "^10.2.2",
+    "strtok3": "^10.3.0",
     "token-types": "^6.0.0",
     "uint8array-extras": "^1.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2342,7 +2342,7 @@ __metadata:
     node-readable-to-web-readable-stream: "npm:^0.4.2"
     remark-cli: "npm:^12.0.1"
     remark-preset-lint-consistent: "npm:^6.0.1"
-    strtok3: "npm:^10.2.2"
+    strtok3: "npm:^10.3.0"
     token-types: "npm:^6.0.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.8.3"
@@ -3190,6 +3190,15 @@ __metadata:
     "@tokenizer/token": "npm:^0.3.0"
     peek-readable: "npm:^7.0.0"
   checksum: 10c0/0d13a7fee7d773693b9e23c53429a032beb1d0ba9ab1cef3b5f3968c2c65f5c292a54af2b54c8e55abd210544e786a2369c8c241c68bb7d80b0ae5b207e4afd9
+  languageName: node
+  linkType: hard
+
+"strtok3@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "strtok3@npm:10.3.0"
+  dependencies:
+    "@tokenizer/token": "npm:^0.3.0"
+  checksum: 10c0/4a39246a25eef0dfd59cd20cdf11bba646696465e357fcc8d6b3faf976e23072004b948ddaf5f32c132d33c731ec810ee2f931a20dca0d3094e4766528aa431d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update dependency [strtok3 v10.3.0](https://github.com/Borewit/strtok3/releases/tag/v10.3.0), deprecating [peek-readable module](https://github.com/Borewit/peek-readable).