### PR TITLE
Add support for MP4 fragments `moof`, `traf`, `tfhd`, and `trak` boxes

### DIFF
--- a/lib/mp4/Atom.ts
+++ b/lib/mp4/Atom.ts
@@ -71,6 +71,7 @@ export class Atom {
       case '<id>':
       case 'ilst':
       case 'tref':
+      case 'moof':
         return this.readAtoms(tokenizer, dataHandler, this.getPayloadLength(remaining));
 
       case 'meta': { // Metadata Atom, ref: https://developer.apple.com/library/content/documentation/QuickTime/QTFF/Metadata/Metadata.html#//apple_ref/doc/uid/TP40000939-CH1-SW8

--- a/test/test-file-mp4.ts
+++ b/test/test-file-mp4.ts
@@ -503,4 +503,14 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
     assert.strictEqual(common.title, undefined, 'common.title');
   });
 
+  it('should be able handle fragmented duration', async () => {
+
+    const filePath = path.join(mp4Samples, 'fragmented-duration.mp4');
+    const {format} = await mm.parseFile(filePath);
+
+    assert.strictEqual(format.container, 'isom/iso6/iso2/avc1/mp41', 'format.container');
+    assert.strictEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
+    assert.approximately(format.duration, 96.98331065759638, 1 / 1000000, 'format.duration');
+  });
+
 });


### PR DESCRIPTION
Add support for decoding `moof`, `traf`, `tfhd`, and `trak` boxes
Add ability to calculate duration of fragmented MP4 files

Resolves #2441 