### PR TITLE
Remove `uint8array-extras` dependency

### DIFF
--- a/lib/apev2/APEv2Parser.ts
+++ b/lib/apev2/APEv2Parser.ts
@@ -1,7 +1,6 @@
 import initDebug from 'debug';
 import * as strtok3 from 'strtok3';
 import { StringType } from 'token-types';
-import { uint8ArrayToString } from 'uint8array-extras';
 
 import * as util from '../common/Util.js';
 import type { IOptions, IApeHeader } from '../type.js';
@@ -19,6 +18,7 @@ import {
 } from './APEv2Token.js';
 import { makeUnexpectedFileContentError } from '../ParseError.js';
 import type { IRandomAccessTokenizer } from 'strtok3';
+import { TextDecoder } from '@kayahr/text-encoding';
 
 const debug = initDebug('music-metadata:parser:APEv2');
 
@@ -172,7 +172,7 @@ export class APEv2Parser extends BasicParser {
             await this.tokenizer.readBuffer(picData);
 
             zero = util.findZero(picData, 0, picData.length);
-            const description = uint8ArrayToString(picData.slice(0, zero));
+            const description = new TextDecoder('utf-8').decode(picData.slice(0, zero));
             const data = picData.slice(zero + 1);
 
             await this.metadata.addTag(tagFormat, key, {

--- a/lib/common/FourCC.ts
+++ b/lib/common/FourCC.ts
@@ -1,5 +1,5 @@
 import type { IToken } from 'strtok3';
-import { stringToUint8Array, uint8ArrayToString } from 'uint8array-extras';
+import { TextDecoder, TextEncoder } from '@kayahr/text-encoding';
 
 import * as util from './Util.js';
 import { InternalParserError, FieldDecodingError } from '../ParseError.js';
@@ -14,7 +14,7 @@ export const FourCcToken: IToken<string> = {
   len: 4,
 
   get: (buf: Uint8Array, off: number): string => {
-    const id = uint8ArrayToString(buf.slice(off, off + FourCcToken.len), 'latin1');
+    const id =  new TextDecoder('latin1').decode(buf.slice(off, off + FourCcToken.len));
     if (!id.match(validFourCC)) {
       throw new FieldDecodingError(`FourCC contains invalid characters: ${util.a2hex(id)} "${id}"`);
     }
@@ -22,7 +22,7 @@ export const FourCcToken: IToken<string> = {
   },
 
   put: (buffer: Uint8Array, offset: number, id: string) => {
-    const str = stringToUint8Array(id);
+    const str = new TextEncoder('latin1').encode(id);
     if (str.length !== 4)
       throw new InternalParserError('Invalid length');
     buffer.set(str, offset);

--- a/lib/common/Util.ts
+++ b/lib/common/Util.ts
@@ -158,3 +158,20 @@ export function toRatio(value: string): IRatio | undefined {
     };
   }
 }
+
+const byteToHexLookupTable = Array.from({length: 256}, (_, index) => index.toString(16).padStart(2, '0'));
+
+export function uint8ArrayToHex(array: Uint8Array): string {
+
+    // Concatenating a string is faster than using an array.
+  let hexString = '';
+
+  // eslint-disable-next-line unicorn/no-for-loop -- Max performance is critical.
+  for (let index = 0; index < array.length; index++) {
+    hexString += byteToHexLookupTable[array[index]];
+  }
+
+  return hexString;
+}
+
+

--- a/lib/mp4/MP4Parser.ts
+++ b/lib/mp4/MP4Parser.ts
@@ -9,7 +9,7 @@ import { ChapterTrackReferenceBox, Mp4ContentError, } from './AtomToken.js';
 import { type AnyTagValue, type IChapter, type ITrackInfo, TrackType } from '../type.js';
 
 import type { IGetToken } from '@tokenizer/token';
-import { uint8ArrayToHex, uint8ArrayToString } from 'uint8array-extras';
+import { uint8ArrayToHex } from '../common/Util.js';
 
 import { TextDecoder } from '@kayahr/text-encoding';
 
@@ -356,7 +356,7 @@ export class MP4Parser extends BasicParser {
 
         default: {
           const uint8Array = await this.tokenizer.readToken<Uint8Array>(new Token.Uint8ArrayType(payLoadLength));
-          this.addWarning(`Unsupported meta-item: ${tagKey}[${child.header.name}] => value=${uint8ArrayToHex(uint8Array)} ascii=${uint8ArrayToString(uint8Array, 'ascii')}`);
+          this.addWarning(`Unsupported meta-item: ${tagKey}[${child.header.name}] => value=${uint8ArrayToHex(uint8Array)} ascii=${new TextDecoder('ascii').decode(uint8Array)}`);
         }
       }
 

--- a/lib/wavpack/WavPackParser.ts
+++ b/lib/wavpack/WavPackParser.ts
@@ -6,7 +6,7 @@ import { BasicParser } from '../common/BasicParser.js';
 import { BlockHeaderToken, type IBlockHeader, type IMetadataId, MetadataIdToken } from './WavPackToken.js';
 
 import initDebug from 'debug';
-import { uint8ArrayToHex } from 'uint8array-extras';
+import { uint8ArrayToHex } from '../common/Util.js';
 import { makeUnexpectedFileContentError } from '../ParseError.js';
 
 const debug = initDebug('music-metadata:parser:WavPack');

--- a/package.json
+++ b/package.json
@@ -113,8 +113,7 @@
     "file-type": "^21.0.0",
     "media-typer": "^1.1.0",
     "strtok3": "^10.3.4",
-    "token-types": "^6.1.0",
-    "uint8array-extras": "^1.4.0"
+    "token-types": "^6.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,7 +2231,6 @@ __metadata:
     token-types: "npm:^6.1.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.2"
-    uint8array-extras: "npm:^1.4.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Remove `uint8array-extras` dependency in favour of having the same TextEncoder everywhere.

Resolves #2474 