### PR TITLE
Fix miscalculation Ogg/Vorbis, duration miscalculation

### DIFF
--- a/lib/ogg/vorbis/VorbisStream.ts
+++ b/lib/ogg/vorbis/VorbisStream.ts
@@ -99,8 +99,8 @@ export class VorbisStream implements IPageConsumer {
     await this.metadata.addTag('vorbis', id, value);
   }
 
-  public calculateDuration(_enfOfStream: boolean) {
-    if (this.lastPageHeader && this.metadata.format.sampleRate && this.lastPageHeader.absoluteGranulePosition >= 0) {
+  public calculateDuration(enfOfStream: boolean) {
+    if (this.lastPageHeader && (enfOfStream || this.lastPageHeader.headerType.lastPage) && this.metadata.format.sampleRate && this.lastPageHeader.absoluteGranulePosition >= 0) {
       // Calculate duration
       this.metadata.setFormat('numberOfSamples', this.lastPageHeader.absoluteGranulePosition);
       this.metadata.setFormat('duration', this.lastPageHeader.absoluteGranulePosition / this.metadata.format.sampleRate);

--- a/test/test-file-ogg.ts
+++ b/test/test-file-ogg.ts
@@ -194,6 +194,25 @@ describe('Parse Ogg', () => {
 
     });
 
+    // https://github.com/Borewit/music-metadata/issues/2518
+    describe('calculate duration', () => {
+
+      it('should not calculate duration, when the duration flag is not set', async () => {
+        const filePath = path.join(oggSamplePath, 'issue_70.ogg');
+        const {format} = await mm.parseFile(filePath);
+        assert.strictEqual(format.codec, 'Vorbis I', 'format.codec');
+        assert.isUndefined(format.duration, 'format.duration');
+      });
+
+      it('should calculate duration, when the duration flag is set', async () => {
+        const filePath = path.join(oggSamplePath, 'issue_70.ogg');
+        const {format} = await mm.parseFile(filePath, {duration: true});
+        assert.strictEqual(format.codec, 'Vorbis I', 'format.codec');
+        assert.approximately(format.duration, 1.32, 0.005, 'format.duration');
+      });
+
+    });
+
   });
 
   describe('Parsing Ogg/Opus', () => {


### PR DESCRIPTION
Fixes miscalculation occurring when Ogg/Vorbis files when the duration option is not explicitly enabled. In that case, the parser performs a partial read of the file and reports the duration based only on the processed portion, resulting in an incomplete value.

Resolves #2584