### PR TITLE
Fix mdhd/mvhd version 1 (64-bit) atom parsing — half duration bug

### DIFF
--- a/lib/mp4/AtomToken.ts
+++ b/lib/mp4/AtomToken.ts
@@ -241,6 +241,14 @@ const SecondsSinceMacEpoch: IGetToken<Date> = {
     return new Date(secondsSinceUnixEpoch * 1000);
   }};
 
+const SecondsSinceMacEpoch64: IGetToken<Date> = {
+  len: 8,
+
+  get: (buf: Uint8Array, off: number): Date => {
+    const secondsSinceUnixEpoch = Number(Token.UINT64_BE.get(buf, off)) - 2082844800;
+    return new Date(secondsSinceUnixEpoch * 1000);
+  }};
+
 /**
  * Token: Media Header Atom
  * Ref:
@@ -253,9 +261,27 @@ export class MdhdAtom extends FixedLengthAtom implements IGetToken<IAtomMdhd> {
   }
 
   public get(buf: Uint8Array, off: number): IAtomMdhd {
+    const version = Token.UINT8.get(buf, off + 0);
+    const flags = Token.UINT24_BE.get(buf, off + 1);
+
+    if (version === 1) {
+      // Version 1: 64-bit creation/modification times and duration
+      return {
+        version,
+        flags,
+        creationTime: SecondsSinceMacEpoch64.get(buf, off + 4),
+        modificationTime: SecondsSinceMacEpoch64.get(buf, off + 12),
+        timeScale: Token.UINT32_BE.get(buf, off + 20),
+        duration: Number(Token.UINT64_BE.get(buf, off + 24)),
+        language: Token.UINT16_BE.get(buf, off + 32),
+        quality: Token.UINT16_BE.get(buf, off + 34)
+      };
+    }
+
+    // Version 0: 32-bit fields
     return {
-      version: Token.UINT8.get(buf, off + 0),
-      flags: Token.UINT24_BE.get(buf, off + 1),
+      version,
+      flags,
       creationTime: SecondsSinceMacEpoch.get(buf, off + 4),
       modificationTime: SecondsSinceMacEpoch.get(buf, off + 8),
       timeScale: Token.UINT32_BE.get(buf, off + 12),
@@ -276,16 +302,43 @@ export class MvhdAtom extends FixedLengthAtom implements IGetToken<IAtomMvhd> {
   }
 
   public get(buf: Uint8Array, off: number): IAtomMvhd {
+    const version = Token.UINT8.get(buf, off);
+    const flags = Token.UINT24_BE.get(buf, off + 1);
+
+    if (version === 1) {
+      // Version 1: 64-bit creation/modification times and duration
+      return {
+        version,
+        flags,
+        creationTime: SecondsSinceMacEpoch64.get(buf, off + 4),
+        modificationTime: SecondsSinceMacEpoch64.get(buf, off + 12),
+        timeScale: Token.UINT32_BE.get(buf, off + 20),
+        duration: Number(Token.UINT64_BE.get(buf, off + 24)),
+        preferredRate: Token.UINT32_BE.get(buf, off + 32),
+        preferredVolume: Token.UINT16_BE.get(buf, off + 36),
+        // ignore reserved: 10 bytes
+        // ignore matrix structure: 36 bytes
+        previewTime: Token.UINT32_BE.get(buf, off + 84),
+        previewDuration: Token.UINT32_BE.get(buf, off + 88),
+        posterTime: Token.UINT32_BE.get(buf, off + 92),
+        selectionTime: Token.UINT32_BE.get(buf, off + 96),
+        selectionDuration: Token.UINT32_BE.get(buf, off + 100),
+        currentTime: Token.UINT32_BE.get(buf, off + 104),
+        nextTrackID: Token.UINT32_BE.get(buf, off + 108)
+      };
+    }
+
+    // Version 0: 32-bit fields
     return {
-      version: Token.UINT8.get(buf, off),
-      flags: Token.UINT24_BE.get(buf, off + 1),
+      version,
+      flags,
       creationTime: SecondsSinceMacEpoch.get(buf, off + 4),
       modificationTime: SecondsSinceMacEpoch.get(buf, off + 8),
       timeScale: Token.UINT32_BE.get(buf, off + 12),
       duration: Token.UINT32_BE.get(buf, off + 16),
       preferredRate: Token.UINT32_BE.get(buf, off + 20),
       preferredVolume: Token.UINT16_BE.get(buf, off + 24),
-      // ignore reserver: 10 bytes
+      // ignore reserved: 10 bytes
       // ignore matrix structure: 36 bytes
       previewTime: Token.UINT32_BE.get(buf, off + 72),
       previewDuration: Token.UINT32_BE.get(buf, off + 76),

--- a/lib/mp4/AtomToken.ts
+++ b/lib/mp4/AtomToken.ts
@@ -7,6 +7,8 @@ import type { IToken, IGetToken } from 'strtok3';
 import { makeUnexpectedFileContentError } from '../ParseError.js';
 import * as util from '../common/Util.js';
 
+import { FieldDecodingError } from '../ParseError.js';
+
 const debug = initDebug('music-metadata:parser:MP4:atom');
 
 export class Mp4ContentError extends makeUnexpectedFileContentError('MP4'){
@@ -264,31 +266,35 @@ export class MdhdAtom extends FixedLengthAtom implements IGetToken<IAtomMdhd> {
     const version = Token.UINT8.get(buf, off + 0);
     const flags = Token.UINT24_BE.get(buf, off + 1);
 
-    if (version === 1) {
-      // Version 1: 64-bit creation/modification times and duration
-      return {
-        version,
-        flags,
-        creationTime: SecondsSinceMacEpoch64.get(buf, off + 4),
-        modificationTime: SecondsSinceMacEpoch64.get(buf, off + 12),
-        timeScale: Token.UINT32_BE.get(buf, off + 20),
-        duration: Number(Token.UINT64_BE.get(buf, off + 24)),
-        language: Token.UINT16_BE.get(buf, off + 32),
-        quality: Token.UINT16_BE.get(buf, off + 34)
-      };
-    }
+    switch (version) {
 
-    // Version 0: 32-bit fields
-    return {
-      version,
-      flags,
-      creationTime: SecondsSinceMacEpoch.get(buf, off + 4),
-      modificationTime: SecondsSinceMacEpoch.get(buf, off + 8),
-      timeScale: Token.UINT32_BE.get(buf, off + 12),
-      duration: Token.UINT32_BE.get(buf, off + 16),
-      language: Token.UINT16_BE.get(buf, off + 20),
-      quality: Token.UINT16_BE.get(buf, off + 22)
-    };
+      case 0:
+        // Version 0: 32-bit fields
+        return {
+          version,
+          flags,
+          creationTime: SecondsSinceMacEpoch.get(buf, off + 4),
+          modificationTime: SecondsSinceMacEpoch.get(buf, off + 8),
+          timeScale: Token.UINT32_BE.get(buf, off + 12),
+          duration: Token.UINT32_BE.get(buf, off + 16),
+          language: Token.UINT16_BE.get(buf, off + 20),
+          quality: Token.UINT16_BE.get(buf, off + 22)
+        };
+
+      case 1:
+        return {
+          version,
+          flags,
+          creationTime: SecondsSinceMacEpoch64.get(buf, off + 4),
+          modificationTime: SecondsSinceMacEpoch64.get(buf, off + 12),
+          timeScale: Token.UINT32_BE.get(buf, off + 20),
+          duration: Number(Token.UINT64_BE.get(buf, off + 24)),
+          language: Token.UINT16_BE.get(buf, off + 32),
+          quality: Token.UINT16_BE.get(buf, off + 34)
+        };
+      default:
+        throw new FieldDecodingError('Invalid mdhd version header');
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes incorrect duration parsing for MP4/M4B files that use version 1 (64-bit) `mdhd` and `mvhd` atoms. These atoms report exactly half the correct duration because the parser was hardcoded for version 0 field offsets only.

## Root Cause

The [ISO 14496-12 spec](https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-SW34) defines two versions of `mdhd`/`mvhd`:

- **Version 0:** 4-byte creation_time, modification_time, and duration
- **Version 1:** 8-byte creation_time, modification_time, and duration

Version 1 shifts the `timeScale` field from offset 12 to offset 20, and `duration` from offset 16 (4 bytes) to offset 24 (8 bytes). The parser read all fields at version 0 offsets regardless of version, causing it to read incorrect values from the middle of 64-bit fields.

## Evidence

Tested with 6 M4B audiobook files. All version 1 files reported exactly half duration; all version 0 files were correct:

| File | mdhd version | ffprobe duration | music-metadata duration (before fix) |
|------|---|---|---|
| File A | v1 (sz:44) | 50177s (13.9h) | 25089s (7.0h) ❌ |
| File B | v1 (sz:44) | 100261s (27.8h) | 50130s (13.9h) ❌ |
| File C | v1 (sz:44) | 206811s (57.4h) | 103405s (28.7h) ❌ |
| File D | v0 (sz:32) | 32267s | 32267s ✅ |
| File E | v0 (sz:32) | 103355s | 103355s ✅ |
| File F | v0 (sz:32) | 36540s | 36540s ✅ |

## Changes

- `MdhdAtom.get()`: Check version field; use 64-bit offsets and `UINT64_BE` for version 1
- `MvhdAtom.get()`: Same version-aware parsing (same bug, same fix)
- Added `SecondsSinceMacEpoch64` token for 64-bit timestamp fields in version 1 atoms

## Tests

All 568 existing tests pass. No regressions.

Resolves #2625