### PR TITLE
fix(id3v2): use ID3v2.3-specific frame-flag bit positions (#2647)

### DIFF
--- a/lib/id3v2/FrameHeader.ts
+++ b/lib/id3v2/FrameHeader.ts
@@ -39,7 +39,27 @@ export function getFrameHeaderLength(majorVer: number): 6 | 10 {
   }
 }
 
-function readFrameFlags(b: Uint8Array): IFrameFlags {
+function readFrameFlags(b: Uint8Array, majorVer: 3 | 4): IFrameFlags {
+  // ID3v2.3 and ID3v2.4 use different bit layouts for the frame status and format flags.
+  if (majorVer === 3) {
+    // ID3v2.3: status `%abc00000`, format `%ijk00000` (https://id3.org/id3v2.3.0)
+    return {
+      status: {
+        tag_alter_preservation: util.getBit(b, 0, 7),
+        file_alter_preservation: util.getBit(b, 0, 6),
+        read_only: util.getBit(b, 0, 5)
+      },
+      format: {
+        compression: util.getBit(b, 1, 7),
+        encryption: util.getBit(b, 1, 6),
+        grouping_identity: util.getBit(b, 1, 5),
+        // Unsynchronisation and data-length-indicator do not exist as per-frame flags in ID3v2.3.
+        unsynchronisation: false,
+        data_length_indicator: false
+      }
+    };
+  }
+  // ID3v2.4: status `%0abc0000`, format `%0h00kmnp` (https://id3.org/id3v2.4.0-structure)
   return {
     status: {
       tag_alter_preservation: util.getBit(b, 0, 6),
@@ -47,7 +67,7 @@ function readFrameFlags(b: Uint8Array): IFrameFlags {
       read_only: util.getBit(b, 0, 4)
     },
     format: {
-      grouping_identity: util.getBit(b, 1, 7),
+      grouping_identity: util.getBit(b, 1, 6),
       compression: util.getBit(b, 1, 3),
       encryption: util.getBit(b, 1, 2),
       unsynchronisation: util.getBit(b, 1, 1),
@@ -92,7 +112,7 @@ function parseFrameHeaderV23V24(uint8Array: Uint8Array, majorVer: 3 | 4, warning
   const header: IFrameHeader = {
     id: textDecode(uint8Array.subarray(0, 4), 'ascii'),
     length: (majorVer === 4 ? UINT32SYNCSAFE : Token.UINT32_BE).get(uint8Array, 4),
-    flags: readFrameFlags(uint8Array.subarray(8, 10))
+    flags: readFrameFlags(uint8Array.subarray(8, 10), majorVer)
   };
 
   if (!header.id.match(/^[A-Z0-9]{4}$/)) {

--- a/test/test-id3v2.3.ts
+++ b/test/test-id3v2.3.ts
@@ -149,6 +149,56 @@ describe('Extract metadata from ID3v2.3 header', () => {
       assert.deepEqual(metadata.format.tagTypes, ['ID3v2.3', 'APEv2', 'ID3v1'], 'format.tagTypes'); // ToDo: has hale APEv2 tag header
     });
 
+    /**
+     * In ID3v2.3 the frame format flag byte uses `%ijk00000`; bits 0-4 are reserved.
+     * They must not be interpreted as the ID3v2.4 `unsynchronisation` (bit 1) and
+     * `data_length_indicator` (bit 0) flags, otherwise the frame payload gets corrupted.
+     * Issue: https://github.com/Borewit/music-metadata/issues/2647
+     */
+    it('should ignore reserved frame-format-flag bits in ID3v2.3 frames', async () => {
+
+      const jpegMagic = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]); // start of a JPEG file
+
+      // Build an ID3v2.3 APIC frame body: <enc><mime\0><type><desc\0><image-data>
+      const mime = new TextEncoder().encode('image/jpeg');
+      const frameBody = new Uint8Array([
+        0x00,           // text encoding: ISO-8859-1
+        ...mime, 0x00,  // MIME type, null-terminated
+        0x03,           // picture type: Cover (front)
+        0x00,           // empty description, null-terminated
+        ...jpegMagic    // (truncated) image data
+      ]);
+
+      // ID3v2.3 frame header: 4-char ID, UINT32_BE size, 2 flag bytes.
+      // The second flag byte has its reserved bit 0 set (0x01). Under the ID3v2.4
+      // layout this is `data_length_indicator`, which would strip the first 4 bytes.
+      const frameHeader = new Uint8Array([
+        0x41, 0x50, 0x49, 0x43,                                 // 'APIC'
+        (frameBody.length >>> 24) & 0xff, (frameBody.length >>> 16) & 0xff,
+        (frameBody.length >>> 8) & 0xff, frameBody.length & 0xff, // size (UINT32_BE)
+        0x00,                                                    // status flags
+        0x01                                                     // format flags: reserved bit 0 set
+      ]);
+
+      const tagBodyLength = frameHeader.length + frameBody.length;
+      // ID3v2 header: "ID3", major=3, revision=0, flags=0, syncsafe size (4 x 7-bit).
+      const id3Header = new Uint8Array([
+        0x49, 0x44, 0x33,       // 'ID3'
+        0x03, 0x00,             // version 2.3.0
+        0x00,                   // header flags
+        (tagBodyLength >>> 21) & 0x7f, (tagBodyLength >>> 14) & 0x7f,
+        (tagBodyLength >>> 7) & 0x7f, tagBodyLength & 0x7f       // syncsafe size
+      ]);
+
+      const buffer = new Uint8Array([...id3Header, ...frameHeader, ...frameBody]);
+
+      const {common} = await mm.parseBuffer(buffer, {mimeType: 'audio/mpeg'});
+
+      assert.isDefined(common.picture, 'common.picture should be present');
+      assert.strictEqual(common.picture[0].format, 'image/jpeg', 'common.picture[0].format');
+      assert.deepEqual(common.picture[0].data, jpegMagic, 'common.picture[0].data (uncorrupted)');
+    });
+
   });
 
   /**


### PR DESCRIPTION
## Summary

- `readFrameFlags` in `lib/id3v2/FrameHeader.ts` applied the ID3v2.4 frame-flag bit layout unconditionally to all ID3 versions.
- ID3v2.3 and ID3v2.4 use different bit positions for the frame status and format flags, and v2.4 adds `unsynchronisation` (format bit 1) and `data_length_indicator` (format bit 0) which **do not exist as per-frame flags in v2.3** (bits 0–4 of the format byte are reserved there).
- When a v2.3 frame leaves those reserved low bits set, the parser falsely triggered `data_length_indicator` (`ID3v2Parser.readFrameData` strips the first 4 bytes) and `unsynchronisation` (byte removal), corrupting the frame payload. For an APIC frame this shifts the MIME-type offset by 4 bytes, producing `"e/jpeg"` instead of `"image/jpeg"` and truncating the image data.

## Changes

- `lib/id3v2/FrameHeader.ts`:
  - Added a `majorVer` parameter to `readFrameFlags` and branched on the version-specific bit layout.
    - **v2.3** (`%abc00000` / `%ijk00000`): status from bits 7/6/5, format `compression`/`encryption`/`grouping_identity` from bits 7/6/5; `unsynchronisation` and `data_length_indicator` are forced `false` (they are not per-frame flags in v2.3).
    - **v2.4** (`%0abc0000` / `%0h00kmnp`): unchanged bit positions, except `grouping_identity` now reads bit 6 per spec (was bit 7 — a pre-existing benign off-by-one noted in the issue).
  - Updated the call site in `parseFrameHeaderV23V24` to pass `majorVer`.
- `test/test-id3v2.3.ts`:
  - Added a regression test that builds an ID3v2.3 tag containing an APIC frame whose format-flag byte has the reserved bit 0 set, parses it via the public `parseBuffer` API, and asserts the picture format is `image/jpeg` (not `e/jpeg`) and the image data is intact. Verified it fails against the pre-fix code (reproducing the `e/jpeg` symptom) and passes with the fix.

Fixes #2647