### PR TITLE
fix: decode ID3v2 text-encoding $02 as UTF-16BE

### DIFF
--- a/lib/common/Util.ts
+++ b/lib/common/Util.ts
@@ -7,6 +7,7 @@ export type StringEncoding =
   'ascii' // Use 'utf-8' or latin1 instead
   | 'utf8' // alias: 'utf-8'
   | 'utf-16le' // alias: 'ucs2', 'ucs-2'
+  | 'utf-16be'
   | 'ucs2' // 'utf-16le'
   | 'base64url'
   | 'latin1' // Same as ISO-8859-1 (alias: 'binary')
@@ -25,7 +26,7 @@ export function getBit(buf: Uint8Array, off: number, bit: number): boolean {
 export function findZero(uint8Array: Uint8Array, encoding?: StringEncoding): number {
   const len = uint8Array.length;
 
-  if (encoding === 'utf-16le') {
+  if (encoding === 'utf-16le' || encoding === 'utf-16be') {
     // Look for 0x00 0x00 on 2-byte boundary
     for (let i = 0; i + 1 < len; i += 2) {
       if (uint8Array[i] === 0 && uint8Array[i + 1] === 0) return i;
@@ -70,6 +71,12 @@ export function decodeString(uint8Array: Uint8Array, encoding: StringEncoding): 
     if ((uint8Array.length & 1) !== 0)
       throw new FieldDecodingError('Expected even number of octets for 16-bit unicode string');
     return decodeString(swapBytes(uint8Array), encoding);
+  }
+  if (encoding === 'utf-16be') {
+    // There is no native UTF-16BE decoder; swap to UTF-16LE and decode that.
+    if ((uint8Array.length & 1) !== 0)
+      throw new FieldDecodingError('Expected even number of octets for 16-bit unicode string');
+    return new StringType(uint8Array.length, 'utf-16le').get(swapBytes(Uint8Array.from(uint8Array)), 0);
   }
   return new StringType(uint8Array.length, encoding).get(uint8Array, 0);
 }

--- a/lib/id3v2/ID3v2Token.ts
+++ b/lib/id3v2/ID3v2Token.ts
@@ -164,7 +164,7 @@ export const TextEncodingToken: IGetToken<ITextEncoding> = {
       case 0x01:
         return {encoding: 'utf-16le', bom: true};
       case 0x02:
-        return {encoding: 'utf-16le', bom: false};
+        return {encoding: 'utf-16be', bom: false};
       case 0x03:
         return {encoding: 'utf8', bom: false};
       default:

--- a/test/test-id3v2-utf16encoded.ts
+++ b/test/test-id3v2-utf16encoded.ts
@@ -26,3 +26,19 @@ it("decode id3v2-utf16", async () => {
   assert.deepEqual(native[1], {id: 'TPE1', value: 'YourEnigma'}, "['ID3v2.4'].TIT2");
   assert.deepEqual(native[2], {id: 'TYER', value: '2014'}, "['ID3v2.4'].TYER");
 });
+
+it('decodes id3v2 UTF-16BE ($02) text frames', async () => {
+  // ID3v2.4 tag with a TIT2 frame using text-encoding $02 (UTF-16BE, no BOM).
+  const syncsafe = (n: number) =>
+    Uint8Array.from([(n >>> 21) & 0x7f, (n >>> 14) & 0x7f, (n >>> 7) & 0x7f, n & 0x7f]);
+  const text = Uint8Array.from([0x00, 0x54, 0x00, 0xEB, 0x00, 0x73, 0x00, 0x74]); // 'T\u00ebst' in UTF-16BE
+  const body = Uint8Array.from([0x02, ...text]);
+  const frame = Uint8Array.from([0x54, 0x49, 0x54, 0x32, ...syncsafe(body.length), 0x00, 0x00, ...body]);
+  const header = Uint8Array.from([0x49, 0x44, 0x33, 0x04, 0x00, 0x00, ...syncsafe(frame.length)]);
+  const mpeg = new Uint8Array(417);
+  mpeg.set([0xFF, 0xFB, 0x90, 0x00], 0);
+  const buf = Buffer.concat([Buffer.from(header), Buffer.from(frame), Buffer.from(mpeg)]);
+
+  const { common } = await mm.parseBuffer(buf, { mimeType: 'audio/mpeg' });
+  assert.strictEqual(common.title, 'T\u00ebst', 'UTF-16BE title decoded without byte swapping');
+});


### PR DESCRIPTION
ID3v2 text-encoding byte `$02` is defined as **"UTF-16BE encoded Unicode without BOM"** (ID3v2.4 §4, "Text encoding"), but `TextEncodingToken` maps it to `utf-16le`:

```ts
case 0x02:
  return {encoding: 'utf-16le', bom: false};   // should be utf-16be
```

Since `$02` carries no BOM, `decodeString` has nothing to trigger its big-endian swap path, so the UTF-16**BE** bytes are decoded little-endian and every non-ASCII character comes out byte-swapped. A `TIT2` frame whose value is `Tëst` (UTF-16BE `00 54 00 EB 00 73 00 74`) is parsed as `吀ëst`-style mojibake (each code unit byte-reversed).

Corroborating the gap: `test/test-util.ts` has a test titled *"find terminator in utf16be encoded string"* that actually passes `'utf-16le'` as the encoding — the codebase had no real UTF-16BE path.

### Impact
Any ID3v2.2/2.3/2.4 tag (MP3/AIFF/WAV) that uses the spec-legal `$02` encoding returns silently corrupted, byte-swapped strings for title/artist/album/etc. on non-ASCII content. It is a less common encoding (most taggers emit `$01`+BOM or `$03` UTF-8), which is why it went unnoticed, but it is valid and produced by some taggers.

### Fix
Map `$02` to `utf-16be`, and handle `utf-16be` in `decodeString` (swap to `utf-16le` for the decode, since there is no native UTF-16BE decoder) and in `findZero` (scan the `00 00` terminator on the 2-byte boundary). UTF-16LE and the BOM paths are unchanged.

### Test
Added a case to `test/test-id3v2-utf16encoded.ts` that builds an ID3v2.4 tag with a `$02`-encoded `TIT2` frame in-memory and asserts the title decodes correctly. It fails on the current code and passes with the fix; the full suite (573 → 576) stays green.
