### PR TITLE
Upgrade TypeScript to 6.0.3 and add `node` types in tsconfig files

### DIFF
--- a/doc-gen/tsconfig.json
+++ b/doc-gen/tsconfig.json
@@ -1,4 +1,7 @@
 {
-  "extends": "../tsconfig.json"
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }
 

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "types": ["node"],
     "sourceMap": true,
     "inlineSources": true,
     "declaration": true,

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "remark-cli": "^12.0.1",
     "remark-preset-lint-consistent": "^6.0.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=18"

--- a/test/test-common.ts
+++ b/test/test-common.ts
@@ -94,7 +94,7 @@ describe('function selectCover()', () => {
         if (cover.type) {
           assert.equal(cover.type, 'Cover (front)', 'cover.type');
         } else {
-          assert.equal(cover.data, common.picture[0].data, 'First picture if no type is defined');
+          assert.equal(cover.data, common.picture![0].data, 'First picture if no type is defined');
         }
       }
     }

--- a/test/test-concurrent-picture.ts
+++ b/test/test-concurrent-picture.ts
@@ -13,7 +13,7 @@ it("should handle concurrent parsing of pictures", () => {
   return Promise.all<void>(files.map(file => {
     return mm.parseFile(file).then(result => {
       const data = fs.readFileSync(`${file}.jpg`);
-      t.deepEqual(result.common.picture[0].data, data, 'check picture');
+      t.deepEqual(result.common.picture![0].data, data, 'check picture');
     });
   }));
 });

--- a/test/test-discogs.ts
+++ b/test/test-discogs.ts
@@ -50,7 +50,7 @@ describe('Discogs mappings', () => {
 
   describe('Track mapping: Beth Hart - Sinner\'s Prayer', () => {
 
-    function checkTags(metadata: mm.IAudioMetadata, tagType, getTagName: (tag: string) => string) {
+    function checkTags(metadata: mm.IAudioMetadata, tagType: string, getTagName: (tag: string) => string) {
 
       const native = mm.orderTags(metadata.native[tagType]);
       const common = metadata.common;
@@ -117,7 +117,7 @@ describe('Discogs mappings', () => {
       // t.deepEqual(format.numberOfSamples, 93624, "format.numberOfSamples");
       assert.deepEqual(format.sampleRate, 44100, 'format.sampleRate');
       assert.deepEqual(format.duration, 2.1681632653061222, 'format.duration');
-      assert.approximately(format.bitrate, 156000, 1000, 'format.bitrate');
+      assert.approximately(format.bitrate as number, 156000, 1000, 'format.bitrate');
       assert.deepEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
 
       // Expect basic common tags
@@ -143,11 +143,6 @@ describe('Discogs mappings', () => {
       const filename = 'Discogs - Beth Hart - Sinner\'s Prayer [APEv2].flac';
       const filePath = path.join(samplePath, filename);
 
-      function _checkNative(id3v23) {
-        // Compare expectedCommonTags with result.common
-        assert.deepEqual(id3v23['TXXX:CATALOGID'], 'PRAR931391');
-      }
-
       // Run with default options
       const metadata = await mm.parseFile(filePath);
 
@@ -167,7 +162,7 @@ describe('Discogs mappings', () => {
 
   describe('Track mapping: Yasmin Levy - Mi Korasón.flac\'', () => {
 
-    function checkTags(metadata: mm.IAudioMetadata, tagType, getTagName: (tag: string) => string) {
+    function checkTags(metadata: mm.IAudioMetadata, tagType: string, getTagName: (tag: string) => string) {
 
       const native = mm.orderTags(metadata.native[tagType]);
       const common = metadata.common;

--- a/test/test-file-aac.ts
+++ b/test/test-file-aac.ts
@@ -13,13 +13,13 @@ describe('Parse ADTS/AAC', () => {
   function checkFormat(format: IFormat, dataFormat: string, codec: string, codecProfile: string, sampleRate: number, channels: number, bitrate: number, samples: number) {
     assert.strictEqual(format.container, dataFormat, 'format.container');
     assert.strictEqual(format.codec, codec, 'format.codec');
-    assert.strictEqual(format.codecProfile, codecProfile, 'format.codecProfile');
+    assert.strictEqual(format.codecProfile!, codecProfile, 'format.codecProfile');
     assert.strictEqual(format.lossless, false, 'format.lossless');
     assert.strictEqual(format.sampleRate, sampleRate, 'format.sampleRate');
     assert.strictEqual(format.numberOfChannels, channels, 'format.numberOfChannels');
-    assert.approximately(format.bitrate, bitrate, 500, 'format.bitrate');
+    assert.approximately(format.bitrate!, bitrate, 500, 'format.bitrate');
     assert.strictEqual(format.numberOfSamples, samples, `format.numberOfSamples = ${samples} samples`);
-    assert.approximately(format.duration, samples / sampleRate, 0.1, 'format.duration');
+    assert.approximately(format.duration!, samples / sampleRate, 0.1, 'format.duration');
     assert.isTrue(format.hasAudio, 'format.hasAudio');
     assert.isFalse(format.hasVideo, 'format.hasAudio');
   }

--- a/test/test-file-aiff.ts
+++ b/test/test-file-aiff.ts
@@ -13,6 +13,7 @@ describe('Parse AIFF (Audio Interchange File Format)', () => {
   function checkFormat(format: mm.IFormat, compressionType: string, sampleRate: number, channels: number, bitsPerSample: number, samples: number) {
     const lossless = compressionType === 'PCM';
     const dataFormat = lossless ? 'AIFF' : 'AIFF-C';
+    assert.isDefined(format.sampleRate, 'format.sampleRate should be defined');
     const duration = samples / format.sampleRate;
     assert.strictEqual(format.container, dataFormat, `format.container = '${dataFormat}'`);
     assert.strictEqual(format.lossless, lossless, `format.lossless = ${lossless}`);

--- a/test/test-file-ape.ts
+++ b/test/test-file-ape.ts
@@ -8,7 +8,7 @@ import type { IPicture } from '../lib/index.js';
 
 describe('Parse APE (Monkey\'s Audio)', () => {
 
-  function checkFormat(format) {
+  function checkFormat(format: mm.IFormat) {
     assert.strictEqual(format.bitsPerSample, 16, 'format.bitsPerSample');
     assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 [kHz]');
     assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels 2 (stereo)');
@@ -17,7 +17,7 @@ describe('Parse APE (Monkey\'s Audio)', () => {
     assert.isFalse(format.hasVideo, 'format.hasAudio');
   }
 
-  function checkCommon(common) {
+  function checkCommon(common: mm.ICommonTagsResult) {
     assert.strictEqual(common.title, '07. Shadow On The Sun', 'common.title');
     assert.strictEqual(common.artist, 'Audioslave', 'common.artist');
     assert.deepEqual(common.artists, ['Audioslave', 'Chris Cornell'], 'common.artists');
@@ -28,10 +28,10 @@ describe('Parse APE (Monkey\'s Audio)', () => {
     assert.deepEqual(common.genre, ['Alternative'], 'common.genre');
     assert.deepEqual(common.track, {no: 7, of: null}, 'common.track');
     assert.deepEqual(common.disk, {no: 3, of: null}, 'common.disk');
-    assert.strictEqual(common.picture[0].format, 'image/jpeg', 'common.picture 0 format');
-    assert.strictEqual(common.picture[0].data.length, 48658, 'common.picture 0 length');
-    assert.strictEqual(common.picture[1].format, 'image/jpeg', 'common.picture 1 format');
-    assert.strictEqual(common.picture[1].data.length, 48658, 'common.picture 1 length');
+    assert.strictEqual(common.picture![0].format, 'image/jpeg', 'common.picture 0 format');
+    assert.strictEqual(common.picture![0].data.length, 48658, 'common.picture 0 length');
+    assert.strictEqual(common.picture![1].format, 'image/jpeg', 'common.picture 1 format');
+    assert.strictEqual(common.picture![1].data.length, 48658, 'common.picture 1 length');
   }
 
   function checkNative(ape: mm.INativeTagDict) {
@@ -68,7 +68,7 @@ describe('Parse APEv2 header', () => {
     assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
     assert.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
     assert.strictEqual(format.tool, 'LAME 3.99r', 'format.codecProfile');
-    assert.approximately(format.duration, 348.421, 1 / 500, 'format.duration');
+    assert.approximately(format.duration!, 348.421, 1 / 500, 'format.duration');
     assert.deepEqual(format.sampleRate, 44100, 'format.sampleRate');
     assert.deepEqual(format.tagTypes, ['ID3v2.4', 'APEv2', 'ID3v1'], 'format.tagTypes');
     assert.strictEqual(format.bitrate, 320000, 'format.bitrate');

--- a/test/test-file-asf.ts
+++ b/test/test-file-asf.ts
@@ -79,16 +79,16 @@ describe('Parse ASF', () => {
 
   describe('parse', () => {
 
-    function checkFormat(format) {
+    function checkFormat(format: mm.IFormat) {
       assert.strictEqual(format.container, 'ASF/audio', 'format.container');
       assert.strictEqual(format.codec, 'Windows Media Audio 9.1', 'format.codec');
-      assert.approximately(format.duration, 243.306, 1 / 10000, 'format.duration');
+      assert.approximately(format.duration!, 243.306, 1 / 10000, 'format.duration');
       assert.strictEqual(format.bitrate, 192639, 'format.bitrate');
       assert.isTrue(format.hasAudio, 'format.hasAudio');
       assert.isFalse(format.hasVideo, 'format.hasVideo');
     }
 
-    function checkCommon(common) {
+    function checkCommon(common: mm.ICommonTagsResult) {
       assert.strictEqual(common.title, 'Don\'t Bring Me Down', 'common.title');
       assert.deepEqual(common.artist, 'Electric Light Orchestra', 'common.artist');
       assert.deepEqual(common.albumartist, 'Electric Light Orchestra', 'common.albumartist');
@@ -147,8 +147,8 @@ describe('Parse ASF', () => {
 
       assert.strictEqual(format.container, 'ASF/audio', 'format.container');
       assert.strictEqual(format.codec, 'Windows Media Audio 9', 'format.codec');
-      assert.approximately(format.duration, 14.466, 1 / 10000, 'format.duration');
-      assert.approximately(format.bitrate, 128639, 1, 'format.bitrate');
+      assert.approximately(format.duration!, 14.466, 1 / 10000, 'format.duration');
+      assert.approximately(format.bitrate!, 128639, 1, 'format.bitrate');
       assert.isTrue(format.hasAudio, 'format.hasAudio');
       assert.isFalse(format.hasVideo, 'format.hasVideo');  });
 

--- a/test/test-file-asf.ts
+++ b/test/test-file-asf.ts
@@ -86,16 +86,16 @@ describe('Parse ASF', () => {
 
   describe('parse', () => {
 
-    function checkFormat(format) {
+    function checkFormat(format: mm.IFormat) {
       assert.strictEqual(format.container, 'ASF/audio', 'format.container');
       assert.strictEqual(format.codec, 'Windows Media Audio 9.1', 'format.codec');
-      assert.approximately(format.duration, 243.306, 1 / 10000, 'format.duration');
+      assert.approximately(format.duration!, 243.306, 1 / 10000, 'format.duration');
       assert.strictEqual(format.bitrate, 192639, 'format.bitrate');
       assert.isTrue(format.hasAudio, 'format.hasAudio');
       assert.isFalse(format.hasVideo, 'format.hasVideo');
     }
 
-    function checkCommon(common) {
+    function checkCommon(common: mm.ICommonTagsResult) {
       assert.strictEqual(common.title, 'Don\'t Bring Me Down', 'common.title');
       assert.deepEqual(common.artist, 'Electric Light Orchestra', 'common.artist');
       assert.deepEqual(common.albumartist, 'Electric Light Orchestra', 'common.albumartist');
@@ -154,8 +154,8 @@ describe('Parse ASF', () => {
 
       assert.strictEqual(format.container, 'ASF/audio', 'format.container');
       assert.strictEqual(format.codec, 'Windows Media Audio 9', 'format.codec');
-      assert.approximately(format.duration, 14.466, 1 / 10000, 'format.duration');
-      assert.approximately(format.bitrate, 128639, 1, 'format.bitrate');
+      assert.approximately(format.duration!, 14.466, 1 / 10000, 'format.duration');
+      assert.approximately(format.bitrate!, 128639, 1, 'format.bitrate');
       assert.isTrue(format.hasAudio, 'format.hasAudio');
       assert.isFalse(format.hasVideo, 'format.hasVideo');  });
 

--- a/test/test-file-flac.ts
+++ b/test/test-file-flac.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import * as mm from '../lib/index.js';
 import { LyricsContentType, TimestampFormat } from '../lib/index.js';
+import type { IVorbisPicture } from '../lib/ogg/vorbis/Vorbis.js';
 import { Parsers } from './metadata-parsers.js';
 import { samplePath } from './util.js';
 
@@ -11,7 +12,7 @@ describe('Parse FLAC Vorbis comment', () => {
 
   const flacFilePath = path.join(samplePath, 'flac');
 
-  function checkFormat(format) {
+  function checkFormat(format: mm.IFormat) {
     assert.strictEqual(format.container, 'FLAC', 'format.container');
     assert.strictEqual(format.codec, 'FLAC', 'format.codec');
     assert.deepEqual(format.tagTypes, ['vorbis'], 'format.tagTypes');
@@ -23,7 +24,7 @@ describe('Parse FLAC Vorbis comment', () => {
     assert.isFalse(format.hasVideo, 'format.hasAudio');
   }
 
-  function checkCommon(common) {
+  function checkCommon(common: mm.ICommonTagsResult) {
     assert.strictEqual(common.title, 'Brian Eno', 'common.title');
     assert.deepEqual(common.artists, ['MGMT'], 'common.artists');
     assert.strictEqual(common.albumartist, undefined, 'common.albumartist');
@@ -32,11 +33,11 @@ describe('Parse FLAC Vorbis comment', () => {
     assert.deepEqual(common.track, {no: 7, of: null}, 'common.track');
     assert.deepEqual(common.disk, {no: null, of: null}, 'common.disk');
     assert.deepEqual(common.genre, ['Alt. Rock'], 'genre');
-    assert.strictEqual(common.picture[0].format, 'image/jpeg', 'common.picture format');
-    assert.strictEqual(common.picture[0].data.length, 175668, 'common.picture length');
+    assert.strictEqual(common.picture![0].format, 'image/jpeg', 'common.picture format');
+    assert.strictEqual(common.picture![0].data.length, 175668, 'common.picture length');
   }
 
-  function checkNative(vorbis) {
+  function checkNative(vorbis: mm.INativeTagDict) {
     // Compare expectedCommonTags with result.common
     assert.deepEqual(vorbis.TITLE, ['Brian Eno'], 'vorbis.TITLE');
     assert.deepEqual(vorbis.ARTIST, ['MGMT'], 'vorbis.ARTIST');
@@ -44,7 +45,7 @@ describe('Parse FLAC Vorbis comment', () => {
     assert.deepEqual(vorbis.TRACKNUMBER, ['07'], 'vorbis.TRACKNUMBER');
     assert.deepEqual(vorbis.GENRE, ['Alt. Rock'], 'vorbis.GENRE');
     assert.deepEqual(vorbis.COMMENT, ['EAC-Secure Mode=should ignore equal sign'], 'vorbis.COMMENT');
-    const pic = vorbis.METADATA_BLOCK_PICTURE[0];
+    const pic = vorbis.METADATA_BLOCK_PICTURE[0] as IVorbisPicture;
 
     assert.strictEqual(pic.type, 'Cover (front)', 'raw METADATA_BLOCK_PICTUREtype');
     assert.strictEqual(pic.format, 'image/jpeg', 'raw METADATA_BLOCK_PICTURE format');
@@ -97,7 +98,7 @@ describe('Parse FLAC Vorbis comment', () => {
     Parsers.forEach(parser => {
       it(parser.description, async function(){
         const {format} = await parser.parse(() => this.skip(), filePath, 'audio/flac');
-        assert.approximately(496000, format.bitrate, 500);
+        assert.approximately(496000, format.bitrate!, 500);
       });
     });
 
@@ -195,8 +196,8 @@ describe('Parse FLAC Vorbis comment', () => {
     assert.isFalse(format.hasVideo, 'format.hasAudio');
 
     assert.isArray(common.lyrics, 'common.lyrics');
-    assert.strictEqual(common.lyrics.length, 1, 'common.lyrics.length');
-    const lrcLyrics = common.lyrics[0];
+    assert.strictEqual(common.lyrics!.length, 1, 'common.lyrics.length');
+    const lrcLyrics = common.lyrics![0];
     assert.strictEqual(lrcLyrics.contentType, LyricsContentType.lyrics, 'lrcLyrics.contentType');
     assert.strictEqual(lrcLyrics.timeStampFormat, TimestampFormat.milliseconds, 'lrcLyrics.timeStampFormat');
     assert.isArray(lrcLyrics.syncText, 'lrcLyrics.syncText');
@@ -227,7 +228,7 @@ describe('Parse FLAC Vorbis comment', () => {
     assert.isArray(common.lyrics, 'common.lyrics');
     assert.isNotEmpty(common.lyrics, 'common.lyrics');
 
-    const unsyncedLyrics = common.lyrics[0].text;
+    const unsyncedLyrics = common.lyrics![0].text;
     assert.strictEqual(
       unsyncedLyrics,
       "Run away, run away, run away\r\n" +

--- a/test/test-file-matroska.ts
+++ b/test/test-file-matroska.ts
@@ -35,7 +35,7 @@ describe('Matroska formats', () => {
       // format chunk information
       assert.strictEqual(format.container, 'EBML/matroska', 'format.container');
       assert.strictEqual(format.codec, 'ALAC', 'format.codec');
-      assert.approximately(format.duration, 196608 / 41000, 1 / 100000, 'format.duration');
+      assert.approximately(format.duration!, 196608 / 41000, 1 / 100000, 'format.duration');
       assert.strictEqual(format.sampleRate, 41000, 'format.sampleRate');
       assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
       assert.isTrue(format.hasAudio, 'format.hasAudio');
@@ -51,7 +51,7 @@ describe('Matroska formats', () => {
       // format chunk information
       assert.strictEqual(format.container, 'EBML/matroska', 'format.container');
       assert.strictEqual(format.codec, 'AAC', 'format.codec');
-      assert.approximately(format.duration, 221184 / 44100, 1 / 100000, 'format.duration');
+      assert.approximately(format.duration!, 221184 / 44100, 1 / 100000, 'format.duration');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
       assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
       assert.isTrue(format.hasAudio, 'format.hasAudio');
@@ -80,7 +80,7 @@ describe('Matroska formats', () => {
       // format chunk information
       assert.strictEqual(format.container, 'EBML/webm', 'format.container');
       assert.strictEqual(format.codec, 'VORBIS', 'format.codec');
-      assert.approximately(format.duration, 7.143, 1 / 100000, 'format.duration');
+      assert.approximately(format.duration!, 7.143, 1 / 100000, 'format.duration');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
       assert.isTrue(format.hasAudio, 'format.hasAudio');
       assert.isTrue(format.hasVideo, 'format.hasVideo');
@@ -102,7 +102,7 @@ describe('Matroska formats', () => {
       // format chunk information
       assert.strictEqual(format.container, 'EBML/webm', 'format.container');
       assert.strictEqual(format.codec, 'OPUS', 'format.codec');
-      assert.approximately(format.duration, 5.006509896, 1 / 100000, 'format.duration');
+      assert.approximately(format.duration!, 5.006509896, 1 / 100000, 'format.duration');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
       assert.isTrue(format.hasAudio, 'format.hasAudio');
       assert.isFalse(format.hasVideo, 'format.hasVideo');
@@ -154,7 +154,7 @@ describe('Matroska formats', () => {
       assert.deepEqual(format.tagTypes, [ 'matroska' ], 'format.tagTypes');
 
       assert.deepEqual(format.codec, 'AAC', 'format.codec');
-      assert.approximately(format.duration, 3.417, 1 / 100000, 'format.duration');
+      assert.approximately(format.duration!, 3.417, 1 / 100000, 'format.duration');
       assert.strictEqual(format.sampleRate, 48000, 'format.sampleRate');
       assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
 

--- a/test/test-file-mp3.ts
+++ b/test/test-file-mp3.ts
@@ -121,7 +121,7 @@ describe('Parse MP3 files', () => {
     const filePath = path.join(samplePath, 'audio-frame-header-bug.mp3');
 
     const result = await mm.parseFile(filePath, {duration: true});
-    assert.approximately(result.format.duration, durationSleepAwayMp3, 1 / 10);
+    assert.approximately(result.format.duration!, durationSleepAwayMp3, 1 / 10);
   });
 
   it('should be able to parse: Sleep Away.mp3', () => {
@@ -141,8 +141,8 @@ describe('Parse MP3 files', () => {
       assert.deepEqual(common.composer, ['Robert R. Acri']);
       assert.deepEqual(common.genre, ['Jazz']);
 
-      assert.strictEqual(common.picture.length, 1, 'should contain the cover');
-      const picture = common.picture[0];
+      assert.strictEqual(common.picture!.length, 1, 'should contain the cover');
+      const picture = common.picture![0];
       assert.strictEqual(picture.description, 'thumbnail');
       assert.strictEqual(picture.format, 'image/jpeg');
       assert.strictEqual(picture.data.length, 27852);
@@ -212,7 +212,7 @@ describe('Parse MP3 files', () => {
 
     assert.strictEqual(common.title, 'Jan Pillemann Otze', 'common.title');
     assert.strictEqual(common.artist, 'Mickie Krause', 'common.artist');
-    assert.approximately(format.duration, 217.86, 0.005, 'format.duration');
+    assert.approximately(format.duration!, 217.86, 0.005, 'format.duration');
   });
 
   it('Able to handle corrupt LAME header', async () => {
@@ -223,7 +223,7 @@ describe('Parse MP3 files', () => {
 
     assert.strictEqual(format.container, 'MPEG', 'format.container');
     assert.strictEqual(format.codec, 'MPEG 2 Layer 3', 'format.codec');
-    assert.approximately(format.duration, 817.92, 1 / 200, 'format.duration');
+    assert.approximately(format.duration!, 817.92, 1 / 200, 'format.duration');
     assert.strictEqual(format.sampleRate, 22050, 'format.sampleRate');
 
     assert.includeDeepMembers(quality.warnings, [{message: 'Corrupt LAME header'}], 'quality.warnings includes: \'Corrupt LAME header\'');
@@ -235,7 +235,7 @@ describe('Parse MP3 files', () => {
 
     function checkFormat(format: mm.IFormat) {
       assert.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.tagTypes');
-      assert.approximately(format.duration, 61.73, 1 / 100, 'format.duration');
+      assert.approximately(format.duration!, 61.73, 1 / 100, 'format.duration');
       assert.strictEqual(format.container, 'MPEG', 'format.container');
       assert.strictEqual(format.codec, 'MPEG 2 Layer 3', 'format.codec');
       assert.strictEqual(format.lossless, false, 'format.lossless');
@@ -273,7 +273,7 @@ describe('Parse MP3 files', () => {
         Parsers.forEach(parser => {
             it(parser.description, async function(){
               const { format } = await parser.parse(() => this.skip(), filePath, 'audio/mpeg', {duration: true});
-              assert.approximately(format.duration, durationSleepAwayMp3, 1 / 10, 'Expect a duration');
+              assert.approximately(format.duration!, durationSleepAwayMp3, 1 / 10, 'Expect a duration');
               assert.strictEqual(format.numberOfSamples, 8831232, 'format.numberOfSamples');
             });
           });
@@ -353,7 +353,7 @@ describe('Parse MP3 files', () => {
         assert.strictEqual(format.codec, 'MPEG 1 Layer 3', 'format.codec');
         assert.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
         assert.strictEqual(format.tool, 'LAME 3.99r', 'format.tool');
-        assert.approximately(format.trackPeakLevel, 0.21857, 5 / 1000000, 'format.trackPeakLevel');
+        assert.approximately(format.trackPeakLevel!, 0.21857, 5 / 1000000, 'format.trackPeakLevel');
         assert.strictEqual(format.trackGain, 6.8, 'format.trackGain');
         assert.isUndefined(format.albumGain, 'format.albumGain');
       });

--- a/test/test-file-mp4.ts
+++ b/test/test-file-mp4.ts
@@ -13,22 +13,22 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
   describe('Parse MPEG-4 files (.m4a)', () => {
 
-    function checkFormat(format) {
+    function checkFormat(format: mm.IFormat) {
       assert.deepEqual(format.lossless, false);
       assert.deepEqual(format.container, 'M4A/isom/iso2', 'container');
       assert.deepEqual(format.codec, 'MPEG-4/AAC', 'codec');
       assert.deepEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
       assert.deepEqual(format.sampleRate, 44100, 'format.sampleRate');
       assert.deepEqual(format.tagTypes, ['iTunes'], 'format.tagTypes');
-      assert.approximately(format.duration, 2.206, 1 / 500, 'format.duration');
+      assert.approximately(format.duration!, 2.206, 1 / 500, 'format.duration');
       assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
       assert.deepEqual(format.bitsPerSample, 16, 'format.bitsPerSample');
-      assert.approximately(format.bitrate, 148000, 500, 'Calculate bit-rate');
+      assert.approximately(format.bitrate!, 148000, 500, 'Calculate bit-rate');
       assert.deepEqual(format.hasAudio, true, 'format.hasAudio');
       assert.deepEqual(format.hasVideo, false, 'format.hasVideo');
     }
 
-    function checkCommon(common) {
+    function checkCommon(common: mm.ICommonTagsResult) {
       assert.strictEqual(common.title, 'Voodoo People (Pendulum Remix)', 'title');
       assert.strictEqual(common.artist, 'The Prodigy', 'artist');
       assert.strictEqual(common.albumartist, 'Pendulum', 'albumartist');
@@ -38,14 +38,14 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
       assert.strictEqual(common.track.of, 12, 'track of');
       assert.strictEqual(common.disk.no, 1, 'disk no');
       assert.strictEqual(common.disk.of, 1, 'disk of');
-      assert.strictEqual(common.genre[0], 'Electronic', 'genre');
-      assert.strictEqual(common.picture[0].format, 'image/jpeg', 'picture 0 format');
-      assert.strictEqual(common.picture[0].data.length, 196450, 'picture 0 length');
-      assert.strictEqual(common.picture[1].format, 'image/jpeg', 'picture 1 format');
-      assert.strictEqual(common.picture[1].data.length, 196450, 'picture 1 length');
+      assert.strictEqual(common.genre![0], 'Electronic', 'genre');
+      assert.strictEqual(common.picture![0].format, 'image/jpeg', 'picture 0 format');
+      assert.strictEqual(common.picture![0].data.length, 196450, 'picture 0 length');
+      assert.strictEqual(common.picture![1].format, 'image/jpeg', 'picture 1 format');
+      assert.strictEqual(common.picture![1].data.length, 196450, 'picture 1 length');
     }
 
-    function checkNativeTags(native) {
+    function checkNativeTags(native: mm.INativeTagDict) {
 
       assert.ok(native, 'Native m4a tags should be present');
 
@@ -66,8 +66,8 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
       // Check album art
       assert.isDefined(native.covr);
-      assert.strictEqual(native.covr[0].format, 'image/jpeg', 'm4a.covr.format');
-      assert.strictEqual(native.covr[0].data.length, 196450, 'm4a.covr.data.length');
+      assert.strictEqual((native.covr[0] as mm.IPicture).format, 'image/jpeg', 'm4a.covr.format');
+      assert.strictEqual((native.covr[0] as mm.IPicture).data.length, 196450, 'm4a.covr.data.length');
     }
 
     Parsers.forEach(parser => {
@@ -189,7 +189,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
           assert.deepEqual(format.container, 'M4A/3gp5/isom', 'format.container');
           assert.deepEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
-          assert.approximately(format.duration, 991.213, 1 / 500, 'format.duration');
+          assert.approximately(format.duration!, 991.213, 1 / 500, 'format.duration');
           assert.deepEqual(format.hasAudio, true, 'format.hasAudio');
           assert.deepEqual(format.hasVideo, false, 'format.hasVideo');
 
@@ -464,8 +464,8 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
     const {format, common} = await mm.parseFile(path.join(mp4Samples, 'issue-387.m4a'));
     assert.strictEqual(format.container, 'M4A/mp42/isom', 'format.container');
     assert.strictEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
-    assert.approximately(format.duration, 224.00290249433107, 1 / 200, 'format.duration');
-    assert.approximately(format.sampleRate, 44100, 1 / 200, 'format.sampleRate');
+    assert.approximately(format.duration!, 224.00290249433107, 1 / 200, 'format.duration');
+    assert.approximately(format.sampleRate!, 44100, 1 / 200, 'format.sampleRate');
     assert.deepEqual(format.hasAudio, true, 'format.hasAudio');
     assert.deepEqual(format.hasVideo, false, 'format.hasVideo');
 
@@ -483,14 +483,14 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
     assert.strictEqual(format.container, 'M4A/isom/mp42', 'format.container');
     assert.strictEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
-    assert.approximately(format.duration, 1.024, 1 / 2000, 'format.duration');
+    assert.approximately(format.duration!, 1.024, 1 / 2000, 'format.duration');
     assert.strictEqual(format.sampleRate, 48000, 'format.sampleRate');
     assert.deepEqual(format.hasAudio, true, 'format.hasAudio');
     assert.deepEqual(format.hasVideo, false, 'format.hasVideo');
 
 
-    assert.strictEqual(format.creationTime.toISOString(), '2021-01-02T17:42:46.000Z', 'format.modificationTime');
-    assert.strictEqual(format.modificationTime.toISOString(), '2021-01-02T17:43:25.000Z', 'format.modificationTime');
+    assert.strictEqual(format.creationTime!.toISOString(), '2021-01-02T17:42:46.000Z', 'format.modificationTime');
+    assert.strictEqual(format.modificationTime!.toISOString(), '2021-01-02T17:43:25.000Z', 'format.modificationTime');
 
     const iTunes = mm.orderTags(native.iTunes);
     assert.strictEqual(iTunes.date[0], '2021-01-02T17:42:05Z', 'moov.udta.date');
@@ -508,7 +508,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
     assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
     assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
     assert.strictEqual(format.bitsPerSample, 16, 'format.bitsPerSample');
-    assert.approximately(format.duration, 360.8, 1 / 20, 'format.duration');
+    assert.approximately(format.duration!, 360.8, 1 / 20, 'format.duration');
     assert.deepEqual(format.hasAudio, true, 'format.hasAudio');
     assert.deepEqual(format.hasVideo, true, 'format.hasVideo');
 
@@ -526,7 +526,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
     assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
     assert.strictEqual(format.sampleRate, 48000, 'format.sampleRate');
     assert.strictEqual(format.bitsPerSample, 16, 'format.bitsPerSample');
-    assert.approximately(format.duration, 1563.16, 1 / 200, 'format.duration');
+    assert.approximately(format.duration!, 1563.16, 1 / 200, 'format.duration');
     assert.deepEqual(format.hasAudio, true, 'format.hasAudio');
     assert.deepEqual(format.hasVideo, false, 'format.hasVideo');
 
@@ -555,7 +555,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
     assert.strictEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
     assert.deepEqual(format.hasAudio, true, 'format.hasAudio');
     assert.deepEqual(format.hasVideo, true, 'format.hasVideo');
-    assert.approximately(format.duration, 60.13968253968254, 1 / 1000000, 'format.duration');
+    assert.approximately(format.duration!, 60.13968253968254, 1 / 1000000, 'format.duration');
 
     assert.strictEqual(common.title, undefined, 'common.title');
   });
@@ -567,10 +567,10 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
 
     assert.strictEqual(format.container, 'isom/iso6/iso2/avc1/mp41', 'format.container');
     assert.strictEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
-    assert.approximately(format.duration, 96.98331065759638, 1 / 1000000, 'format.duration');
+    assert.approximately(format.duration!, 96.98331065759638, 1 / 1000000, 'format.duration');
     assert.strictEqual(format.hasAudio, true, 'format.hasAudio');
     assert.strictEqual(format.hasVideo, true, 'format.hasVideo');
-    assert.approximately(format.bitrate, 127947,1/2 ,'format.bitrate');
+    assert.approximately(format.bitrate!, 127947,1/2 ,'format.bitrate');
   });
 
   it('bitrate id4.m4a', async () => {
@@ -582,7 +582,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
     assert.strictEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
     assert.strictEqual(format.hasAudio, true, 'format.hasAudio');
     assert.strictEqual(format.hasVideo, false, 'format.hasVideo');
-    assert.approximately(format.bitrate, 147916,1,'format.bitrate');
+    assert.approximately(format.bitrate!, 147916,1,'format.bitrate');
   });
 
   // https://github.com/Borewit/music-metadata/issues/2672
@@ -598,7 +598,7 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
     assert.strictEqual(format.codec, 'MPEG-4/AAC', 'format.codec');
     assert.strictEqual(format.numberOfChannels, 1, 'format.numberOfChannels');
     assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
-    assert.approximately(format.duration, 4, 1 / 1000, 'format.duration');
+    assert.approximately(format.duration!, 4, 1 / 1000, 'format.duration');
     assert.strictEqual(format.hasAudio, true, 'format.hasAudio');
     assert.strictEqual(format.hasVideo, false, 'format.hasVideo');
   });

--- a/test/test-file-mpeg.ts
+++ b/test/test-file-mpeg.ts
@@ -86,11 +86,11 @@ describe('Parse MPEG', () => {
 
       const filePath = path.join(samplePath, '04 - You Don\'t Know.mp3');
 
-      function checkFormat(format) {
+      function checkFormat(format: mm.IFormat) {
         t.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.tagTypes');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
         t.strictEqual(format.numberOfSamples, 9098496, 'format.numberOfSamples'); // FooBar says 3:26.329 seconds (9.099.119 samples)
-        t.approximately(format.duration, 206.3, 1 / 10, 'format.duration'); // FooBar says 3:26.329 seconds (9.099.119 samples)
+        t.approximately(format.duration!, 206.3, 1 / 10, 'format.duration'); // FooBar says 3:26.329 seconds (9.099.119 samples)
         t.strictEqual(format.bitrate, 320000, 'format.bitrate = 128 kbit/sec');
         t.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels 2 (stereo)');
 
@@ -98,7 +98,7 @@ describe('Parse MPEG', () => {
         // t.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
       }
 
-      function checkCommon(common) {
+      function checkCommon(common: mm.ICommonTagsResult) {
         t.strictEqual(common.title, 'You Don\'t Know', 'common.title');
         t.deepEqual(common.artists, ['Reel Big Fish'], 'common.artists');
         t.strictEqual(common.albumartist, 'Reel Big Fish', 'common.albumartist');
@@ -153,18 +153,18 @@ describe('Parse MPEG', () => {
 
       const filePath = path.join(samplePath, '07 - I\'m Cool.mp3');
 
-      function checkFormat(format) {
+      function checkFormat(format: mm.IFormat) {
         t.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.type');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
         // t.strictEqual(format.numberOfSamples, 8040655, 'format.numberOfSamples'); // FooBar says 8.040.655 samples
-        t.approximately(format.duration, 200.9, 1 / 10, 'format.duration'); // FooBar says 3:26.329 seconds
+        t.approximately(format.duration!, 200.9, 1 / 10, 'format.duration'); // FooBar says 3:26.329 seconds
         t.strictEqual(format.bitrate, 320000, 'format.bitrate = 128 kbit/sec');
         t.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels 2 (stereo)');
         // t.strictEqual(format.codec, 'LAME3.98r', 'format.codec'); // 'LAME3.91' found on position 81BCF=531407// 'LAME3.91' found on position 81BCF=531407
         // t.strictEqual(format.codecProfile, 'CBR', 'format.codecProfile');
       }
 
-      function checkCommon(common) {
+      function checkCommon(common: mm.ICommonTagsResult) {
         t.strictEqual(common.title, 'I\'m Cool', 'common.title');
         t.deepEqual(common.artists, ['Reel Big Fish'], 'common.artists');
         t.strictEqual(common.albumartist, 'Reel Big Fish', 'common.albumartist');
@@ -223,7 +223,7 @@ describe('Parse MPEG', () => {
        ------------------------------------------------------------------------*/
       const filePath = path.join(samplePath, 'outofbounds.mp3');
 
-      function checkFormat(format) {
+      function checkFormat(format: mm.IFormat) {
         t.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v1'], 'format.type');
         t.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
         t.strictEqual(format.bitrate, 320000, 'format.bitrate = 128 kbit/sec');
@@ -244,7 +244,7 @@ describe('Parse MPEG', () => {
    */
   describe('Multiple ID3 tags: ID3v2.3, ID3v2.4 & ID3v1', () => {
 
-    function checkFormat(format: mm.IFormat, expectedDuration) {
+    function checkFormat(format: mm.IFormat, expectedDuration: number) {
       t.deepEqual(format.tagTypes, ['ID3v2.3', 'ID3v2.4', 'ID3v1'], 'format.tagTypes');
       t.strictEqual(format.duration, expectedDuration, 'format.duration');
       t.deepEqual(format.container, 'MPEG', 'format.container');
@@ -301,7 +301,7 @@ describe('Parse MPEG', () => {
       });
       const idv23 = mm.orderTags(metadata.native['ID3v2.3']);
       assert.deepEqual(idv23.POPM[0], {email: 'no@email', rating: 128, counter: 0}, 'ID3v2.3 POPM');
-      assert.approximately(metadata.common.rating[0].rating, 0.5, 1 / (2 * 254), 'Common rating');
+      assert.approximately(metadata.common.rating![0].rating!, 0.5, 1 / (2 * 254), 'Common rating');
     });
 
     it('from \'id3v2-lyrics.mp3\'', async () => {
@@ -311,7 +311,7 @@ describe('Parse MPEG', () => {
       // Native rating value
       assert.deepEqual(idv23.POPM[0], {email: 'MusicBee', rating: 255, counter: 0}, 'ID3v2.3 POPM');
       // Common rating value
-      assert.approximately(metadata.common.rating[0].rating, 1, 0, 'Common rating');
+      assert.approximately(metadata.common.rating![0].rating!, 1, 0, 'Common rating');
     });
 
     it('decode POPM without a counter field', async () => {
@@ -354,7 +354,7 @@ describe('Parse MPEG', () => {
 
       const metadata = await mm.parseStream(stream, {mimeType: 'audio/mpeg'}, {duration: true});
       // Changed expected result from 34.66 to 34.64, to 34,69 (strtok3@10.2.0) after updating strtok3
-      assert.approximately(metadata.format.duration, 34.69, 5 / 1000);
+      assert.approximately(metadata.format.duration!, 34.69, 5 / 1000);
     });
 
   });

--- a/test/test-file-musepack.ts
+++ b/test/test-file-musepack.ts
@@ -20,7 +20,7 @@ describe('Parse Musepack (.mpc)', () => {
         assert.deepEqual(format.container, 'Musepack, SV7');
         assert.strictEqual(format.sampleRate, 44100);
         assert.strictEqual(format.numberOfSamples, 11940);
-        assert.approximately(format.bitrate, 269649, 1);
+        assert.approximately(format.bitrate!, 269649, 1);
         assert.strictEqual(format.codec, '1.15');
         assert.isTrue(format.hasAudio, 'format.hasAudio');
         assert.isFalse(format.hasVideo, 'format.hasAudio');
@@ -55,7 +55,7 @@ describe('Parse Musepack (.mpc)', () => {
         assert.deepEqual(format.container, 'Musepack, SV7');
         assert.strictEqual(format.sampleRate, 44100);
         assert.strictEqual(format.numberOfSamples, 11940);
-        assert.approximately(format.bitrate, 269649, 1);
+        assert.approximately(format.bitrate!, 269649, 1);
         assert.strictEqual(format.codec, '1.15');
 
         // Check generic metadata
@@ -82,8 +82,8 @@ describe('Parse Musepack (.mpc)', () => {
         assert.strictEqual(format.sampleRate, 48000);
         assert.strictEqual(format.numberOfSamples, 24000);
         assert.strictEqual(format.numberOfChannels, 2);
-        assert.approximately(format.duration, 0.5, 1 / 2000);
-        assert.approximately(format.bitrate, 32368, 1);
+        assert.approximately(format.duration!, 0.5, 1 / 2000);
+        assert.approximately(format.bitrate!, 32368, 1);
 
         // Check generic metadata
         assert.strictEqual(common.title, 'Goldberg Variations, BWV 988: Variatio 4 a 1 Clav.');

--- a/test/test-file-ogg.ts
+++ b/test/test-file-ogg.ts
@@ -5,12 +5,14 @@ import { Parsers } from './metadata-parsers.js';
 import * as mm from '../lib/index.js';
 import { samplePath } from './util.js';
 import { IdHeader } from '../lib/ogg/opus/Opus.js';
+import { IVorbisPicture } from '../lib/ogg/vorbis/Vorbis.js';
+import { IFormat } from '../lib/index.js';
 
 const oggSamplePath = path.join(samplePath, 'ogg');
 
 describe('Parse Ogg', () => {
 
-  function check_Nirvana_In_Bloom_commonTags(common) {
+  function check_Nirvana_In_Bloom_commonTags(common: mm.ICommonTagsResult) {
     assert.strictEqual(common.title, 'In Bloom', 'common.title');
     assert.strictEqual(common.artist, 'Nirvana', 'common.artist');
     assert.strictEqual(common.albumartist, 'Nirvana', 'common.albumartist');
@@ -19,15 +21,15 @@ describe('Parse Ogg', () => {
     assert.deepEqual(common.track, {no: 2, of: 12}, 'common.track');
     assert.deepEqual(common.disk, {no: 1, of: 1}, 'common.disk');
     assert.deepEqual(common.genre, ['Grunge', 'Alternative'], 'genre');
-    assert.strictEqual(common.picture[0].format, 'image/jpeg', 'picture format');
-    assert.strictEqual(common.picture[0].data.length, 30966, 'picture length');
+    assert.strictEqual(common.picture![0].format, 'image/jpeg', 'picture format');
+    assert.strictEqual(common.picture![0].data.length, 30966, 'picture length');
     assert.strictEqual(common.barcode, '0720642442524', 'common.barcode (including leading zero)');
     assert.strictEqual(common.asin, 'B000003TA4', 'common.asin');
     assert.deepEqual(common.catalognumber, ['GED24425'], 'common.asin');
     assert.deepEqual(common.isrc, ['USGF19942502'], 'common.isrc');
   }
 
-  function check_Nirvana_In_Bloom_VorbisTags(vorbis) {
+  function check_Nirvana_In_Bloom_VorbisTags(vorbis: mm.INativeTagDict) {
 
     assert.deepEqual(vorbis.TRACKNUMBER, ['2'], 'vorbis.TRACKNUMBER');
     assert.deepEqual(vorbis.TRACKTOTAL, ['12'], 'vorbis.TRACKTOTAL');
@@ -36,9 +38,9 @@ describe('Parse Ogg', () => {
     assert.deepEqual(vorbis.GENRE, ['Grunge', 'Alternative'], 'vorbis.GENRE');
     assert.deepEqual(vorbis.TITLE, ['In Bloom'], 'vorbis.TITLE');
 
-    const cover = vorbis.METADATA_BLOCK_PICTURE[0];
+    const cover = vorbis.METADATA_BLOCK_PICTURE[0] as IVorbisPicture;
 
-    assert.strictEqual(cover.format, 'image/jpeg', 'vorbis.METADATA_BLOCK_PICTURE format');
+    assert.strictEqual(cover!.format, 'image/jpeg', 'vorbis.METADATA_BLOCK_PICTURE format');
     assert.strictEqual(cover.type, 'Cover (front)', 'vorbis.METADATA_BLOCK_PICTURE tagTypes');
     // test exact contents too
     assert.strictEqual(cover.data.length, 30966, 'vorbis.METADATA_BLOCK_PICTURE length');
@@ -97,7 +99,7 @@ describe('Parse Ogg', () => {
 
       const filePath = path.join(oggSamplePath, 'nirvana-2sec.vorbis.ogg');
 
-      function checkFormat(format) {
+      function checkFormat(format: mm.IFormat) {
         assert.deepEqual(format.tagTypes, ['vorbis'], 'format.tagTypes');
         assert.strictEqual(format.duration, 2.0, 'format.duration [seconds]');
         assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate [hz]');
@@ -188,9 +190,9 @@ describe('Parse Ogg', () => {
       assert.strictEqual(common.track.of, 5, 'track of');
       assert.strictEqual(common.disk.no, 1, 'disk no');
       assert.strictEqual(common.disk.of, 1, 'disk of');
-      assert.strictEqual(common.genre[0], 'Dubstep', 'genre');
-      assert.strictEqual(common.picture[0].format, 'image/jpeg', 'picture format');
-      assert.strictEqual(common.picture[0].data.length, 207439, 'picture length');
+      assert.strictEqual(common.genre![0], 'Dubstep', 'genre');
+      assert.strictEqual(common.picture![0].format, 'image/jpeg', 'picture format');
+      assert.strictEqual(common.picture![0].data.length, 207439, 'picture length');
 
     });
 
@@ -208,7 +210,7 @@ describe('Parse Ogg', () => {
         const filePath = path.join(oggSamplePath, 'issue_70.ogg');
         const {format} = await mm.parseFile(filePath, {duration: true});
         assert.strictEqual(format.codec, 'Vorbis I', 'format.codec');
-        assert.approximately(format.duration, 1.32, 0.005, 'format.duration');
+        assert.approximately(format.duration!, 1.32, 0.005, 'format.duration');
       });
 
     });
@@ -223,7 +225,7 @@ describe('Parse Ogg', () => {
         try {
           const _idHeader = new IdHeader(18);
         } catch (err) {
-          expect(err.message).to.equal('ID-header-page 0 should be at least 19 bytes long');
+          expect((err as Error).message).to.equal('ID-header-page 0 should be at least 19 bytes long');
         }
       });
     });
@@ -232,10 +234,10 @@ describe('Parse Ogg', () => {
 
       const filePath = path.join(oggSamplePath, 'nirvana-2sec.opus.ogg');
 
-      function checkFormat(format) {
+      function checkFormat(format: IFormat) {
         assert.deepEqual(format.tagTypes, ['vorbis'], 'format.tagTypes');
         assert.strictEqual(format.numberOfSamples, 96000, 'format.numberOfSamples = 96000');
-        assert.approximately(format.duration, 2.0, 1 / 200, 'format.duration = 2.0 sec');
+        assert.approximately(format.duration!, 2.0, 1 / 200, 'format.duration = 2.0 sec');
         assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
         assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels = 2 (stereo)');
         assert.isTrue(format.hasAudio, 'format.hasAudio');
@@ -261,7 +263,7 @@ describe('Parse Ogg', () => {
 
       const filePath = path.join(samplePath, 'female_scrub.spx');
 
-      function checkFormat(format) {
+      function checkFormat(format: IFormat) {
         assert.strictEqual(format.container, 'Ogg', 'format.container');
         assert.strictEqual(format.codec, 'Speex 1.0beta1');
         assert.strictEqual(format.sampleRate, 8000, 'format.sampleRate = 8 kHz');
@@ -290,7 +292,7 @@ describe('Parse Ogg', () => {
 
       assert.isTrue(format.hasAudio, 'format.hasAudio');
       assert.isTrue(format.hasVideo, 'format.hasAudio');
-      assert.approximately(format.duration, 5.758548752834467, 1/1000000, 'format.duration');
+      assert.approximately(format.duration!, 5.758548752834467, 1/1000000, 'format.duration');
     });
 
   });
@@ -334,7 +336,7 @@ describe('Parse Ogg', () => {
       assert.strictEqual(format.codec, 'Opus', 'format.codec');
       assert.strictEqual(format.sampleRate, 48000, 'format.sampleRate');
       assert.strictEqual(format.numberOfSamples, 253440, 'format.numberOfSamples');
-      assert.approximately(format.duration, 5.28, 1 / 200, 'format.duration');
+      assert.approximately(format.duration!, 5.28, 1 / 200, 'format.duration');
     });
 
     it('with no last page', async() => {
@@ -347,7 +349,7 @@ describe('Parse Ogg', () => {
       assert.strictEqual(format.codec, 'Opus', 'format.codec');
       assert.strictEqual(format.sampleRate, 16000, 'format.sampleRate');
       assert.strictEqual(format.numberOfSamples, 270720, 'format.numberOfSamples');
-      assert.approximately(format.duration, 5.64, 1 / 200, 'format.duration');
+      assert.approximately(format.duration!, 5.64, 1 / 200, 'format.duration');
 
       assert.includeDeepMembers(quality.warnings, [{message: 'End-of-stream reached before reaching last page in Ogg stream serial=0'}]);
     });

--- a/test/test-file-ogg.ts
+++ b/test/test-file-ogg.ts
@@ -5,12 +5,14 @@ import { Parsers } from './metadata-parsers.js';
 import * as mm from '../lib/index.js';
 import { samplePath } from './util.js';
 import { IdHeader } from '../lib/ogg/opus/Opus.js';
+import type { IVorbisPicture } from '../lib/ogg/vorbis/Vorbis.js';
+import type { IFormat } from '../lib/index.js';
 
 const oggSamplePath = path.join(samplePath, 'ogg');
 
 describe('Parse Ogg', () => {
 
-  function check_Nirvana_In_Bloom_commonTags(common) {
+  function check_Nirvana_In_Bloom_commonTags(common: mm.ICommonTagsResult) {
     assert.strictEqual(common.title, 'In Bloom', 'common.title');
     assert.strictEqual(common.artist, 'Nirvana', 'common.artist');
     assert.strictEqual(common.albumartist, 'Nirvana', 'common.albumartist');
@@ -19,15 +21,15 @@ describe('Parse Ogg', () => {
     assert.deepEqual(common.track, {no: 2, of: 12}, 'common.track');
     assert.deepEqual(common.disk, {no: 1, of: 1}, 'common.disk');
     assert.deepEqual(common.genre, ['Grunge', 'Alternative'], 'genre');
-    assert.strictEqual(common.picture[0].format, 'image/jpeg', 'picture format');
-    assert.strictEqual(common.picture[0].data.length, 30966, 'picture length');
+    assert.strictEqual(common.picture![0].format, 'image/jpeg', 'picture format');
+    assert.strictEqual(common.picture![0].data.length, 30966, 'picture length');
     assert.strictEqual(common.barcode, '0720642442524', 'common.barcode (including leading zero)');
     assert.strictEqual(common.asin, 'B000003TA4', 'common.asin');
     assert.deepEqual(common.catalognumber, ['GED24425'], 'common.asin');
     assert.deepEqual(common.isrc, ['USGF19942502'], 'common.isrc');
   }
 
-  function check_Nirvana_In_Bloom_VorbisTags(vorbis) {
+  function check_Nirvana_In_Bloom_VorbisTags(vorbis: mm.INativeTagDict) {
 
     assert.deepEqual(vorbis.TRACKNUMBER, ['2'], 'vorbis.TRACKNUMBER');
     assert.deepEqual(vorbis.TRACKTOTAL, ['12'], 'vorbis.TRACKTOTAL');
@@ -36,9 +38,9 @@ describe('Parse Ogg', () => {
     assert.deepEqual(vorbis.GENRE, ['Grunge', 'Alternative'], 'vorbis.GENRE');
     assert.deepEqual(vorbis.TITLE, ['In Bloom'], 'vorbis.TITLE');
 
-    const cover = vorbis.METADATA_BLOCK_PICTURE[0];
+    const cover = vorbis.METADATA_BLOCK_PICTURE[0] as IVorbisPicture;
 
-    assert.strictEqual(cover.format, 'image/jpeg', 'vorbis.METADATA_BLOCK_PICTURE format');
+    assert.strictEqual(cover!.format, 'image/jpeg', 'vorbis.METADATA_BLOCK_PICTURE format');
     assert.strictEqual(cover.type, 'Cover (front)', 'vorbis.METADATA_BLOCK_PICTURE tagTypes');
     // test exact contents too
     assert.strictEqual(cover.data.length, 30966, 'vorbis.METADATA_BLOCK_PICTURE length');
@@ -97,7 +99,7 @@ describe('Parse Ogg', () => {
 
       const filePath = path.join(oggSamplePath, 'nirvana-2sec.vorbis.ogg');
 
-      function checkFormat(format) {
+      function checkFormat(format: mm.IFormat) {
         assert.deepEqual(format.tagTypes, ['vorbis'], 'format.tagTypes');
         assert.strictEqual(format.duration, 2.0, 'format.duration [seconds]');
         assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate [hz]');
@@ -188,9 +190,9 @@ describe('Parse Ogg', () => {
       assert.strictEqual(common.track.of, 5, 'track of');
       assert.strictEqual(common.disk.no, 1, 'disk no');
       assert.strictEqual(common.disk.of, 1, 'disk of');
-      assert.strictEqual(common.genre[0], 'Dubstep', 'genre');
-      assert.strictEqual(common.picture[0].format, 'image/jpeg', 'picture format');
-      assert.strictEqual(common.picture[0].data.length, 207439, 'picture length');
+      assert.strictEqual(common.genre![0], 'Dubstep', 'genre');
+      assert.strictEqual(common.picture![0].format, 'image/jpeg', 'picture format');
+      assert.strictEqual(common.picture![0].data.length, 207439, 'picture length');
 
     });
 
@@ -208,7 +210,7 @@ describe('Parse Ogg', () => {
         const filePath = path.join(oggSamplePath, 'issue_70.ogg');
         const {format} = await mm.parseFile(filePath, {duration: true});
         assert.strictEqual(format.codec, 'Vorbis I', 'format.codec');
-        assert.approximately(format.duration, 1.32, 0.005, 'format.duration');
+        assert.approximately(format.duration!, 1.32, 0.005, 'format.duration');
       });
 
     });
@@ -223,7 +225,7 @@ describe('Parse Ogg', () => {
         try {
           const _idHeader = new IdHeader(18);
         } catch (err) {
-          expect(err.message).to.equal('ID-header-page 0 should be at least 19 bytes long');
+          expect((err as Error).message).to.equal('ID-header-page 0 should be at least 19 bytes long');
         }
       });
     });
@@ -232,10 +234,10 @@ describe('Parse Ogg', () => {
 
       const filePath = path.join(oggSamplePath, 'nirvana-2sec.opus.ogg');
 
-      function checkFormat(format) {
+      function checkFormat(format: IFormat) {
         assert.deepEqual(format.tagTypes, ['vorbis'], 'format.tagTypes');
         assert.strictEqual(format.numberOfSamples, 96000, 'format.numberOfSamples = 96000');
-        assert.approximately(format.duration, 2.0, 1 / 200, 'format.duration = 2.0 sec');
+        assert.approximately(format.duration!, 2.0, 1 / 200, 'format.duration = 2.0 sec');
         assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate = 44.1 kHz');
         assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels = 2 (stereo)');
         assert.isTrue(format.hasAudio, 'format.hasAudio');
@@ -261,7 +263,7 @@ describe('Parse Ogg', () => {
 
       const filePath = path.join(samplePath, 'female_scrub.spx');
 
-      function checkFormat(format) {
+      function checkFormat(format: IFormat) {
         assert.strictEqual(format.container, 'Ogg', 'format.container');
         assert.strictEqual(format.codec, 'Speex 1.0beta1');
         assert.strictEqual(format.sampleRate, 8000, 'format.sampleRate = 8 kHz');
@@ -308,7 +310,7 @@ describe('Parse Ogg', () => {
 
       assert.isTrue(format.hasAudio, 'format.hasAudio');
       assert.isTrue(format.hasVideo, 'format.hasAudio');
-      assert.approximately(format.duration, 5.758548752834467, 1/1000000, 'format.duration');
+      assert.approximately(format.duration!, 5.758548752834467, 1/1000000, 'format.duration');
     });
 
   });
@@ -352,7 +354,7 @@ describe('Parse Ogg', () => {
       assert.strictEqual(format.codec, 'Opus', 'format.codec');
       assert.strictEqual(format.sampleRate, 48000, 'format.sampleRate');
       assert.strictEqual(format.numberOfSamples, 253440, 'format.numberOfSamples');
-      assert.approximately(format.duration, 5.28, 1 / 200, 'format.duration');
+      assert.approximately(format.duration!, 5.28, 1 / 200, 'format.duration');
     });
 
     it('with no last page', async() => {
@@ -365,7 +367,7 @@ describe('Parse Ogg', () => {
       assert.strictEqual(format.codec, 'Opus', 'format.codec');
       assert.strictEqual(format.sampleRate, 16000, 'format.sampleRate');
       assert.strictEqual(format.numberOfSamples, 270720, 'format.numberOfSamples');
-      assert.approximately(format.duration, 5.64, 1 / 200, 'format.duration');
+      assert.approximately(format.duration!, 5.64, 1 / 200, 'format.duration');
 
       assert.includeDeepMembers(quality.warnings, [{message: 'End-of-stream reached before reaching last page in Ogg stream serial=0'}]);
     });

--- a/test/test-file-wav.ts
+++ b/test/test-file-wav.ts
@@ -123,7 +123,7 @@ describe('Parse RIFF/WAVE audio format', () => {
     assert.strictEqual(format.bitsPerSample, 24);
     assert.strictEqual(format.bitrate, 2304000, 'format.bitrate = 2304000 bits/s');
     assert.strictEqual(format.numberOfSamples, 363448);
-    assert.strictEqual(metadata.format.duration, format.numberOfSamples / format.sampleRate, 'file\'s duration');
+    assert.strictEqual(metadata.format.duration!, format.numberOfSamples! / format.sampleRate!, 'file\'s duration');
   });
 
   describe('non-PCM', () => {
@@ -141,7 +141,7 @@ describe('Parse RIFF/WAVE audio format', () => {
         assert.strictEqual(format.bitrate, 89240, 'format.bitrate = 89240 bits/s');
         assert.strictEqual(format.bitsPerSample, 4);
         assert.strictEqual(format.numberOfSamples, 4660260);
-        assert.strictEqual(metadata.format.duration, format.numberOfSamples / format.sampleRate, 'file\'s duration is 3\'31"');
+        assert.strictEqual(metadata.format.duration!, format.numberOfSamples! / format.sampleRate!, 'file\'s duration is 3\'31"');
       });
     });
 
@@ -233,7 +233,7 @@ describe('Parse RIFF/WAVE audio format', () => {
     assert.strictEqual(format.codec, 'PCM', 'format.codec');
     assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
     assert.strictEqual(format.bitrate, 2116800, 'format.bitrate = 2116800 bits/s');
-    assert.approximately(format.duration, 3 / 44100, 1 / 20000, 'format.duration');
+    assert.approximately(format.duration!, 3 / 44100, 1 / 20000, 'format.duration');
   });
 
   // https://github.com/Borewit/music-metadata/issues/819
@@ -246,7 +246,7 @@ describe('Parse RIFF/WAVE audio format', () => {
     assert.strictEqual(format.codec, 'PCM');
     assert.strictEqual(format.bitrate, 256000, 'format.bitrate = 256000 bits/s');
     // assert.strictEqual(format.numberOfSamples, 2158080, 'format.numberOfSamples');
-    assert.approximately(format.duration, 2478 / 16000, 5 / 1000, 'format.duration');
+    assert.approximately(format.duration!, 2478 / 16000, 5 / 1000, 'format.duration');
   });
 
   // https://github.com/Borewit/music-metadata/issues/1163

--- a/test/test-file-wav.ts
+++ b/test/test-file-wav.ts
@@ -123,7 +123,7 @@ describe('Parse RIFF/WAVE audio format', () => {
     assert.strictEqual(format.bitsPerSample, 24);
     assert.strictEqual(format.bitrate, 2304000, 'format.bitrate = 2304000 bits/s');
     assert.strictEqual(format.numberOfSamples, 363448);
-    assert.strictEqual(metadata.format.duration, format.numberOfSamples / format.sampleRate, 'file\'s duration');
+    assert.strictEqual(metadata.format.duration!, format.numberOfSamples! / format.sampleRate!, 'file\'s duration');
   });
 
   it('should decode LIST-INFO tags as UTF-8', async () => {
@@ -181,7 +181,7 @@ describe('Parse RIFF/WAVE audio format', () => {
         assert.strictEqual(format.bitrate, 89240, 'format.bitrate = 89240 bits/s');
         assert.strictEqual(format.bitsPerSample, 4);
         assert.strictEqual(format.numberOfSamples, 4660260);
-        assert.strictEqual(metadata.format.duration, format.numberOfSamples / format.sampleRate, 'file\'s duration is 3\'31"');
+        assert.strictEqual(metadata.format.duration!, format.numberOfSamples! / format.sampleRate!, 'file\'s duration is 3\'31"');
       });
     });
 
@@ -273,7 +273,7 @@ describe('Parse RIFF/WAVE audio format', () => {
     assert.strictEqual(format.codec, 'PCM', 'format.codec');
     assert.strictEqual(format.sampleRate, 44100, 'format.sampleRate');
     assert.strictEqual(format.bitrate, 2116800, 'format.bitrate = 2116800 bits/s');
-    assert.approximately(format.duration, 3 / 44100, 1 / 20000, 'format.duration');
+    assert.approximately(format.duration!, 3 / 44100, 1 / 20000, 'format.duration');
   });
 
   // https://github.com/Borewit/music-metadata/issues/819
@@ -286,7 +286,7 @@ describe('Parse RIFF/WAVE audio format', () => {
     assert.strictEqual(format.codec, 'PCM');
     assert.strictEqual(format.bitrate, 256000, 'format.bitrate = 256000 bits/s');
     // assert.strictEqual(format.numberOfSamples, 2158080, 'format.numberOfSamples');
-    assert.approximately(format.duration, 2478 / 16000, 5 / 1000, 'format.duration');
+    assert.approximately(format.duration!, 2478 / 16000, 5 / 1000, 'format.duration');
   });
 
   // https://github.com/Borewit/music-metadata/issues/1163

--- a/test/test-file-wavpack.ts
+++ b/test/test-file-wavpack.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { Parsers } from './metadata-parsers.js';
 import { samplePath } from './util.js';
+import { ICommonTagsResult, IFormat } from '../lib/index.js';
 
 const wavpackSamplePath = path.join(samplePath, 'wavpack');
 
@@ -10,16 +11,16 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
   describe('codec: WavPack', () => {
 
-    function checkFormat(format) {
+    function checkFormat(format: IFormat) {
       assert.strictEqual(format.container, 'WavPack', 'format.container');
       assert.deepEqual(format.tagTypes, ['APEv2'], 'format.tagTypes');
-      assert.approximately(format.duration, 2.123, 1 / 1000, 'format.duration');
+      assert.approximately(format.duration!, 2.123, 1 / 1000, 'format.duration');
       assert.strictEqual(format.codec, 'PCM', 'format.codecProfile');
       assert.isTrue(format.hasAudio, 'format.hasAudio');
       assert.isFalse(format.hasVideo, 'format.hasAudio');
     }
 
-    function checkCommon(common) {
+    function checkCommon(common: ICommonTagsResult) {
       assert.strictEqual(common.title, 'Sinner\'s Prayer', 'common.title');
       assert.deepEqual(common.artists, ['Beth Hart', 'Joe Bonamassa'], 'common.artist');
     }
@@ -37,7 +38,7 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
   describe('codec: DSD128', () => {
 
-    function checkFormat(format) {
+    function checkFormat(format: IFormat) {
       assert.strictEqual(format.container, 'WavPack', 'format.container');
       assert.strictEqual(format.codec, 'DSD', 'format.codecProfile');
       assert.deepEqual(format.numberOfSamples, 564480, 'format.numberOfSamples');
@@ -58,14 +59,14 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
   describe('codec: DSD128 compressed', () => {
 
-    function checkFormat(format) {
+    function checkFormat(format: IFormat) {
       assert.strictEqual(format.container, 'WavPack', 'format.container');
       assert.strictEqual(format.codec, 'DSD', 'format.codecProfile');
       assert.deepEqual(format.numberOfSamples, 564480, 'format.numberOfSamples');
       assert.strictEqual(format.sampleRate, 5644800, 'format.sampleRate');
       assert.strictEqual(format.duration, 0.1, 'format.duration');
       assert.deepEqual(format.tagTypes, [], 'format.tagTypes');
-      assert.approximately(format.bitrate, 4810400, 1);
+      assert.approximately(format.bitrate!, 4810400, 1);
     }
 
     const wv1 = path.join(wavpackSamplePath, 'DSD128 high compression.wv');

--- a/test/test-file-wavpack.ts
+++ b/test/test-file-wavpack.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { Parsers } from './metadata-parsers.js';
 import { samplePath } from './util.js';
+import type { ICommonTagsResult, IFormat } from '../lib/index.js';
 
 const wavpackSamplePath = path.join(samplePath, 'wavpack');
 
@@ -10,16 +11,16 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
   describe('codec: WavPack', () => {
 
-    function checkFormat(format) {
+    function checkFormat(format: IFormat) {
       assert.strictEqual(format.container, 'WavPack', 'format.container');
       assert.deepEqual(format.tagTypes, ['APEv2'], 'format.tagTypes');
-      assert.approximately(format.duration, 2.123, 1 / 1000, 'format.duration');
+      assert.approximately(format.duration!, 2.123, 1 / 1000, 'format.duration');
       assert.strictEqual(format.codec, 'PCM', 'format.codecProfile');
       assert.isTrue(format.hasAudio, 'format.hasAudio');
       assert.isFalse(format.hasVideo, 'format.hasAudio');
     }
 
-    function checkCommon(common) {
+    function checkCommon(common: ICommonTagsResult) {
       assert.strictEqual(common.title, 'Sinner\'s Prayer', 'common.title');
       assert.deepEqual(common.artists, ['Beth Hart', 'Joe Bonamassa'], 'common.artist');
     }
@@ -37,7 +38,7 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
   describe('codec: DSD128', () => {
 
-    function checkFormat(format) {
+    function checkFormat(format: IFormat) {
       assert.strictEqual(format.container, 'WavPack', 'format.container');
       assert.strictEqual(format.codec, 'DSD', 'format.codecProfile');
       assert.deepEqual(format.numberOfSamples, 564480, 'format.numberOfSamples');
@@ -58,14 +59,14 @@ describe('Parse WavPack (audio/x-wavpack)', () => {
 
   describe('codec: DSD128 compressed', () => {
 
-    function checkFormat(format) {
+    function checkFormat(format: IFormat) {
       assert.strictEqual(format.container, 'WavPack', 'format.container');
       assert.strictEqual(format.codec, 'DSD', 'format.codecProfile');
       assert.deepEqual(format.numberOfSamples, 564480, 'format.numberOfSamples');
       assert.strictEqual(format.sampleRate, 5644800, 'format.sampleRate');
       assert.strictEqual(format.duration, 0.1, 'format.duration');
       assert.deepEqual(format.tagTypes, [], 'format.tagTypes');
-      assert.approximately(format.bitrate, 4810400, 1);
+      assert.approximately(format.bitrate!, 4810400, 1);
     }
 
     const wv1 = path.join(wavpackSamplePath, 'DSD128 high compression.wv');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,11 @@
     "module": "node16",
     "moduleResolution": "node16",
     "target": "ES2020",
-    "esModuleInterop": true,
-    "baseUrl": "."
+    "esModuleInterop": true
+  },
+  "ts-node": {
+    "compilerOptions": {
+      "types": ["node", "mocha"]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "node16",
     "target": "ES2020",
     "esModuleInterop": true,
-    "baseUrl": "."
+    "types": ["node", "mocha"],
+    "strict": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,7 +2299,7 @@ __metadata:
     strtok3: "npm:^10.3.5"
     token-types: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     uint8array-extras: "npm:^1.5.0"
     win-guid: "npm:^0.2.1"
   languageName: unknown
@@ -3317,23 +3317,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2306,7 +2306,7 @@ __metadata:
     strtok3: "npm:^10.3.5"
     token-types: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     uint8array-extras: "npm:^1.5.0"
     win-guid: "npm:^0.2.1"
   languageName: unknown
@@ -3324,23 +3324,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades the TypeScript toolchain to 6.0.3 and updates compiler/test typing for compatibility.

**Changes:**
- Upgrade TypeScript and lockfile entries.
- Explicitly configure Node/Mocha ambient types.
- Add test annotations and non-null assertions required by the new compiler.