### PR TITLE
fix(id3v2): decode UTF-16 ($01) frames with a big-endian BOM

### DIFF
--- a/lib/id3v2/FrameParser.ts
+++ b/lib/id3v2/FrameParser.ts
@@ -507,12 +507,12 @@ export class FrameParser {
     if (zeroIndex >= valueArray.length) {
       // No terminator found, decode full buffer remainder
       return {
-        text: util.decodeString(valueArray, encoding.encoding),
+        text: util.decodeString(uint8Array, encoding.encoding),
         len: originalLen
       };
     }
 
-    const txt = valueArray.subarray(0, zeroIndex);
+    const txt = uint8Array.subarray(0, bomSize + zeroIndex);
     return {
       text: util.decodeString(txt, encoding.encoding),
       len: bomSize + zeroIndex + FrameParser.getNullTerminatorLength(encoding.encoding)

--- a/test/test-id3v2-utf16encoded.ts
+++ b/test/test-id3v2-utf16encoded.ts
@@ -42,3 +42,26 @@ it('decodes id3v2 UTF-16BE ($02) text frames', async () => {
   const { common } = await mm.parseBuffer(buf, { mimeType: 'audio/mpeg' });
   assert.strictEqual(common.title, 'T\u00ebst', 'UTF-16BE title decoded without byte swapping');
 });
+
+it('decodes id3v2 UTF-16 ($01) frames with a big-endian BOM', async () => {
+  // ID3v2.3 tag with a COMM frame using text-encoding $01 (UTF-16 with BOM),
+  // where the BOM is big-endian (0xFE 0xFF).
+  const syncsafe = (n: number) =>
+    Uint8Array.from([(n >>> 21) & 0x7f, (n >>> 14) & 0x7f, (n >>> 7) & 0x7f, n & 0x7f]);
+  const u32be = (n: number) =>
+    Uint8Array.from([(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff]);
+  const body = Uint8Array.from([
+    0x01,                         // encoding: UTF-16 with BOM
+    0x65, 0x6e, 0x67,             // language 'eng'
+    0xFE, 0xFF, 0x00, 0x00,       // descriptor: BE BOM + terminator (empty)
+    0xFE, 0xFF, 0x00, 0x54, 0x00, 0xEB, 0x00, 0x73, 0x00, 0x74 // 'T\u00ebst' in UTF-16BE with BE BOM
+  ]);
+  const frame = Uint8Array.from([0x43, 0x4f, 0x4d, 0x4d, ...u32be(body.length), 0x00, 0x00, ...body]);
+  const header = Uint8Array.from([0x49, 0x44, 0x33, 0x03, 0x00, 0x00, ...syncsafe(frame.length)]);
+  const mpeg = new Uint8Array(417);
+  mpeg.set([0xFF, 0xFB, 0x90, 0x00], 0);
+  const buf = Buffer.concat([Buffer.from(header), Buffer.from(frame), Buffer.from(mpeg)]);
+
+  const { common } = await mm.parseBuffer(buf, { mimeType: 'audio/mpeg' });
+  assert.strictEqual(common.comment[0].text, 'T\u00ebst', 'UTF-16 comment decoded using big-endian BOM');
+});


### PR DESCRIPTION
### Bug

`FrameParser.readNullTerminatedString` decodes UTF-16 text-encoding `$01` ("UTF-16 encoded Unicode with BOM") frames incorrectly when the BOM is big-endian.

The method strips the leading BOM (`bomSize`) and then calls `decodeString(valueArray, 'utf-16le')` on the remainder with a hard-coded little-endian encoding. Once the BOM is removed there is nothing left to signal the byte order, so a field written with a big-endian BOM (`0xFE 0xFF`) is decoded byte-swapped. This affects any null-terminated UTF-16 field: `COMM`, `USLT`, `WXXX`, `GEOB`, `UFID`, `PRIV`, etc.

`decodeString` already resolves byte order from the BOM (it handles both `0xFF 0xFE` and `0xFE 0xFF`) — the same mechanism used for `T*` frames, which decode big-endian BOMs correctly. Null-terminated fields just weren't routed through it with the BOM intact.

### Repro

An ID3v2.3 `COMM` frame with encoding `$01`, a big-endian BOM, and text `Tëst`:

```
01 65 6e 67                          enc=$01, lang 'eng'
FE FF 00 00                          descriptor: BE BOM + terminator
FE FF 00 54 00 EB 00 73 00 74        text: BE BOM + "Tëst" (UTF-16BE)
```

Before: `common.comment[0].text === '吀猀琀'` (byte-swapped).
After: `common.comment[0].text === 'Tëst'`.

### Fix

Hand the BOM-inclusive slice to `decodeString` instead of the BOM-stripped one. The terminator search and all length arithmetic are unchanged, so byte offsets are identical; only the decoded string changes. Little-endian BOM, explicit UTF-16BE (`$02`), UTF-8 and latin1 paths are unaffected.

Adds a regression test.
