### PR TITLE
Decode RIFF LIST-INFO tag values as UTF-8

### DIFF
--- a/lib/riff/RiffChunk.ts
+++ b/lib/riff/RiffChunk.ts
@@ -36,6 +36,6 @@ export class ListInfoTagValue implements IGetToken<string> {
   }
 
   public get(buf: Uint8Array, off: number): string {
-    return new Token.StringType(this.tagHeader.chunkSize, 'ascii').get(buf, off);
+    return new Token.StringType(this.tagHeader.chunkSize, 'utf8').get(buf, off);
   }
 }

--- a/test/test-file-wav.ts
+++ b/test/test-file-wav.ts
@@ -126,6 +126,46 @@ describe('Parse RIFF/WAVE audio format', () => {
     assert.strictEqual(metadata.format.duration, format.numberOfSamples / format.sampleRate, 'file\'s duration');
   });
 
+  it('should decode LIST-INFO tags as UTF-8', async () => {
+
+    const u32 = (n: number): Uint8Array => {
+      const b = new Uint8Array(4);
+      new DataView(b.buffer).setUint32(0, n, true);
+      return b;
+    };
+    const ascii = (str: string): Uint8Array => Uint8Array.from(str, c => c.charCodeAt(0));
+    const concat = (...parts: Uint8Array[]): Uint8Array => {
+      const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+      let off = 0;
+      for (const p of parts) { out.set(p, off); off += p.length; }
+      return out;
+    };
+
+    const expected = 'Tïtle \u{1F600}';
+    const title = new TextEncoder().encode(expected);
+    const inam = concat(ascii('INAM'), u32(title.length), title, new Uint8Array(title.length % 2));
+    const info = concat(ascii('INFO'), inam);
+    const list = concat(ascii('LIST'), u32(info.length), info);
+
+    const fmt = new Uint8Array(24);
+    fmt.set(ascii('fmt '), 0);
+    const fmtView = new DataView(fmt.buffer);
+    fmtView.setUint32(4, 16, true);
+    fmtView.setUint16(8, 1, true);
+    fmtView.setUint16(10, 1, true);
+    fmtView.setUint32(12, 8000, true);
+    fmtView.setUint32(16, 8000, true);
+    fmtView.setUint16(20, 1, true);
+    fmtView.setUint16(22, 8, true);
+
+    const data = concat(ascii('data'), u32(2), new Uint8Array(2));
+    const body = concat(ascii('WAVE'), fmt, list, data);
+    const riff = concat(ascii('RIFF'), u32(body.length), body);
+
+    const metadata = await mm.parseBuffer(riff, {mimeType: 'audio/wav'});
+    assert.strictEqual(metadata.common.title, expected, 'common.title');
+  });
+
   describe('non-PCM', () => {
 
     it('should parse Microsoft 4-bit ADPCM encoded', () => {


### PR DESCRIPTION
`ListInfoTagValue` reads RIFF LIST-INFO tag values with the `ascii` decoder:

```ts
return new Token.StringType(this.tagHeader.chunkSize, 'ascii').get(buf, off);
```

Node's `ascii` decoding masks off the high bit of every byte, so a non-ASCII tag is not merely mis-mapped, it is destroyed.

Tagging a WAV with ffmpeg and reading it back:

| | title |
|---|---|
| bytes on disk | `54 c3 af 74 6c 65 20 f0 9f 98 80` |
| ffprobe | `Tïtle 😀` |
| music-metadata 11.14.0 | `TC/tle p` |

`c3` becomes `43` `C`, `af` becomes `2f` `/`, `f0` becomes `70` `p`, and so on: every byte with the high bit set loses it. `Buffer.from(bytes).toString('ascii')` reproduces the parsed output exactly.

## Change

One character class: `'ascii'` to `'utf8'`.

ffmpeg writes these tags as UTF-8 and ffprobe reads them as UTF-8. ASCII content decodes identically under UTF-8, so files that were parsed correctly before still are, and the existing sample suite passes unchanged (586 to 587 with the new test).

I considered `latin1` instead, since RIFF INFO predates any encoding declaration. It would at least be lossless, but it would mojibake the UTF-8 that current writers actually produce, so `utf8` seemed the better match for real files. Happy to switch if you would rather keep the legacy interpretation.

## Test

Added to `test/test-file-wav.ts`. It builds a minimal RIFF/WAVE in memory with a UTF-8 `INAM` chunk and parses it with `parseBuffer`, so no new sample file is needed. Reverting `RiffChunk.ts` and keeping the test fails it.
