### PR TITLE
Map the APEv2 Date key to the common date field

### DIFF
--- a/lib/apev2/APEv2TagMapper.ts
+++ b/lib/apev2/APEv2TagMapper.ts
@@ -11,6 +11,7 @@ const apev2TagMap: INativeTagMap = {
   'Album Artist': 'albumartist',
   Album: 'album',
   Year: 'date',
+  Date: 'date',
   Originalyear: 'originalyear',
   Originaldate: 'originaldate',
   Releasedate: 'releasedate',

--- a/test/test-picard-mappings.ts
+++ b/test/test-picard-mappings.ts
@@ -134,6 +134,14 @@ describe('Picard mapping coverage', () => {
 
   });
 
+  it('APEv2 accepts the Vorbis-convention Date key', () => {
+
+    const apeTagMapper = new APEv2TagMapper();
+
+    assert.equal(apeTagMapper.tagMap.YEAR, 'date', 'APEv2 Year');
+    assert.equal(apeTagMapper.tagMap.DATE, 'date', 'APEv2 Date');
+  });
+
   it('ID3v2.4.0', () => {
 
     /**


### PR DESCRIPTION
The APEv2 map carries `Year` but not `Date`, so a file tagged with the Vorbis-convention key parses the tag correctly into `native.APEv2` and then never reaches `common`.

Tagging a WavPack file with ffmpeg and reading it back on 11.14.0:

```
native.APEv2   genre, title, artist, album, date, track, encoder
common.year    undefined
common.date    undefined
```

ffprobe reads `"date": "2021"` from the same file, and `native.APEv2` shows music-metadata read it too, so nothing is wrong with the parse. Only the mapping is missing.

## Change

One line, `Date: 'date'` alongside the existing `Year: 'date'`. With it, that file gives `common.year === 2021`.

ffmpeg writes `Date` rather than `Year` when tagging WavPack, which is how I ran into this. The map already accepts several Vorbis-convention keys next to their APE equivalents, `DISCNUMBER` beside `Disc` among them, so this seemed consistent with what the file already does rather than a new policy.

If you would rather keep the map strictly to the APE key list and treat `Date` as ffmpeg's problem, that is a reasonable call and I will close this.

## Test

Added integration coverage in `test/test-file-ape.ts` using `test/samples/monkeysaudio-date.ape`, an approximately 84 KB fixture derived from the existing `monkeysaudio.ape` sample with its tags and artwork replaced by `Date=2021-06-15`. It contains no `Year` tag, so that cannot mask a missing `Date` mapping.

The test exercises all six public parser inputs and verifies the native APEv2 tag, `common.date === '2021-06-15'`, `common.year === 2021`, and absence of parser warnings. Removing the `Date` mapping makes all six new tests fail.

Validation: 592 passing, 1 pending in the full suite; TypeScript checking and targeted lint pass. FFmpeg also successfully decodes the fixture.

