### PR TITLE
fix(mp4): only read a sound sample description from an audio track

### DIFF
--- a/lib/mp4/MP4Parser.ts
+++ b/lib/mp4/MP4Parser.ts
@@ -130,6 +130,26 @@ function distinct(value: AnyTagValue, index: number, self: AnyTagValue[]) {
   return self.indexOf(value) === index;
 }
 
+/**
+ * Determine if a track carries audio.
+ *
+ * Ref: ISO/IEC 14496-12, 8.5.2: the sample entries in a sample description box are track-type specific,
+ * selected by the handler type of the enclosing track. Only a 'soun' track holds an AudioSampleEntry, so
+ * only such a track may be described by a sound sample description.
+ *
+ * Falls back to the sample description when no handler box was found, preserving the previous behaviour.
+ */
+function isAudioTrack(track: ITrackDescription): boolean {
+  const [ssd] = track.soundSampleDescription ?? [];
+  if (!ssd) {
+    return false;
+  }
+  if (track.isAudio) {
+    return track.isAudio();
+  }
+  return !!ssd.description && ssd.description.numAudioChannels > 0;
+}
+
 /*
  * Parser for the MP4 (MPEG-4 Part 14) container format
  * Standard: ISO/IEC 14496-14
@@ -197,6 +217,7 @@ export class MP4Parser extends BasicParser {
     const formatList: string[] = [];
     this.tracks.forEach(track => {
       const trackFormats: string[] = [];
+      const trackIsAudio = isAudioTrack(track);
 
       track.soundSampleDescription.forEach(ssd => {
         const streamInfo: ITrackInfo = {};
@@ -207,7 +228,7 @@ export class MP4Parser extends BasicParser {
         } else {
           streamInfo.codecName = `<${ssd.dataFormat}>`;
         }
-        if (ssd.description) {
+        if (trackIsAudio && ssd.description) {
           const {description} = ssd;
           if (description.sampleRate > 0) {
             streamInfo.type = TrackType.audio;
@@ -230,9 +251,7 @@ export class MP4Parser extends BasicParser {
       this.metadata.setFormat('codec', formatList.filter(distinct).join('+'));
     }
 
-    const audioTracks = [...this.tracks.values()].filter(track => {
-      return track.soundSampleDescription.length >= 1 && track.soundSampleDescription[0].description && track.soundSampleDescription[0].description.numAudioChannels > 0;
-    });
+    const audioTracks = [...this.tracks.values()].filter(isAudioTrack);
 
     // Calculate duration and bitrate of audio tracks
     for (const audioTrack of audioTracks) {
@@ -696,13 +715,20 @@ export class MP4Parser extends BasicParser {
     };
 
     let offset = 0;
-    if (sampleDescription.description) {
-      const version = AtomToken.SoundSampleDescriptionVersion.get(sampleDescription.description, offset);
+    const {description} = sampleDescription;
+    // Only an AudioSampleEntry carries a sound sample description; it is at least 20 bytes beyond the
+    // 16-byte SampleEntry base. A shorter description belongs to another sample entry class, or is truncated.
+    if (description && description.length >= AtomToken.SoundSampleDescriptionVersion.len) {
+      const version = AtomToken.SoundSampleDescriptionVersion.get(description, offset);
       offset += AtomToken.SoundSampleDescriptionVersion.len;
 
       if (version.version === 0 || version.version === 1) {
         // Sound Sample Description (Version 0)
-        ssd.description = AtomToken.SoundSampleDescriptionV0.get(sampleDescription.description, offset);
+        if (description.length >= offset + AtomToken.SoundSampleDescriptionV0.len) {
+          ssd.description = AtomToken.SoundSampleDescriptionV0.get(description, offset);
+        } else {
+          debug(`Warning: sound-sample-description too short: ${description.length} bytes`);
+        }
       } else {
         debug(`Warning: sound-sample-description ${version} not implemented`);
       }

--- a/lib/mp4/MP4Parser.ts
+++ b/lib/mp4/MP4Parser.ts
@@ -134,10 +134,11 @@ function distinct(value: AnyTagValue, index: number, self: AnyTagValue[]) {
  * Determine if a track carries audio.
  *
  * Ref: ISO/IEC 14496-12, 8.5.2: the sample entries in a sample description box are track-type specific,
- * selected by the handler type of the enclosing track. Only a 'soun' track holds an AudioSampleEntry, so
- * only such a track may be described by a sound sample description.
+ * selected by the handler type of the enclosing track. Only an audio track holds an AudioSampleEntry, so
+ * only such a track may be described by a sound sample description; `isAudio()` treats both the 'soun'
+ * and 'audi' handler types as audio.
  *
- * Falls back to the sample description when no handler box was found, preserving the previous behaviour.
+ * Falls back to the sample description when no handler box was found, preserving the previous behavior.
  */
 function isAudioTrack(track: ITrackDescription): boolean {
   const [ssd] = track.soundSampleDescription ?? [];

--- a/test/test-file-mp4.ts
+++ b/test/test-file-mp4.ts
@@ -655,3 +655,164 @@ describe('Track Header (tkhd) atom', () => {
   });
 
 });
+
+describe('Sample Description (stsd) atom', () => {
+
+  const textEncoder = new TextEncoder();
+  const timeScale = 44100;
+
+  function concat(...parts: Uint8Array[]): Uint8Array {
+    const buf = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
+    let offset = 0;
+    for (const part of parts) {
+      buf.set(part, offset);
+      offset += part.length;
+    }
+    return buf;
+  }
+
+  /**
+   * Build a box: 32-bit size, 4-character type, then the payload.
+   */
+  function box(type: string, ...payloads: Uint8Array[]): Uint8Array {
+    const header = new Uint8Array(8);
+    const body = concat(...payloads);
+    new DataView(header.buffer).setUint32(0, header.length + body.length);
+    header.set(textEncoder.encode(type), 4);
+    return concat(header, body);
+  }
+
+  function handlerBox(handlerType: string): Uint8Array {
+    const payload = new Uint8Array(24);
+    payload.set(textEncoder.encode(handlerType), 8);
+    return box('hdlr', payload);
+  }
+
+  function trackHeaderBox(trackId: number): Uint8Array {
+    const payload = new Uint8Array(84);
+    new DataView(payload.buffer).setUint32(12, trackId);
+    return box('tkhd', payload);
+  }
+
+  function mediaHeaderBox(): Uint8Array {
+    const payload = new Uint8Array(24);
+    const view = new DataView(payload.buffer);
+    view.setUint32(12, timeScale);
+    view.setUint32(16, timeScale); // duration: one second
+    return box('mdhd', payload);
+  }
+
+  function sampleSizeBox(): Uint8Array {
+    return box('stsz', new Uint8Array(12)); // sample_size and sample_count both zero
+  }
+
+  /**
+   * A sample description box holding a single entry of the given size.
+   *
+   * Ref: ISO/IEC 14496-12, 8.5.2. A SampleEntry is 16 bytes: the box header, 6 reserved bytes and the
+   * data reference index. An AudioSampleEntry adds 20 bytes on top, whereas other sample entry classes,
+   * such as a MetaDataSampleEntry, may be no larger than the 16-byte base.
+   */
+  function sampleDescriptionBox(dataFormat: string, entrySize: number, audioLike = false): Uint8Array {
+    const header = new Uint8Array(8);
+    new DataView(header.buffer).setUint32(4, 1); // entry_count
+
+    const entry = new Uint8Array(entrySize);
+    const view = new DataView(entry.buffer);
+    view.setUint32(0, entrySize);
+    entry.set(textEncoder.encode(dataFormat), 4);
+    view.setUint16(14, 1); // data_reference_index
+
+    if (audioLike) {
+      // Populate the bytes an AudioSampleEntry would use, to prove they are not read from a non-audio track
+      view.setUint16(24, 2); // channel count
+      view.setUint16(26, 16); // sample size
+      view.setUint16(32, timeScale); // sample rate
+    }
+    return box('stsd', header, entry);
+  }
+
+  interface ITrackSpec {
+    handler: string;
+    dataFormat: string;
+    entrySize: number;
+    audioLike?: boolean;
+    handlerAfterMinf?: boolean;
+  }
+
+  const videoTrack: ITrackSpec = {handler: 'vide', dataFormat: 'avc1', entrySize: 36};
+
+  function trackBox(trackId: number, spec: ITrackSpec): Uint8Array {
+    const hdlr = handlerBox(spec.handler);
+    const stbl = box('stbl', sampleDescriptionBox(spec.dataFormat, spec.entrySize, spec.audioLike), sampleSizeBox());
+    const minf = box('minf', stbl);
+    // Readers are required to accept any box order
+    const mdia = spec.handlerAfterMinf
+      ? box('mdia', mediaHeaderBox(), minf, hdlr)
+      : box('mdia', hdlr, mediaHeaderBox(), minf);
+    return box('trak', trackHeaderBox(trackId), mdia);
+  }
+
+  function mp4(...tracks: ITrackSpec[]): Uint8Array {
+    const ftyp = box('ftyp', textEncoder.encode('isom'), new Uint8Array([0, 0, 2, 0]), textEncoder.encode('isomiso2mp41'));
+    const moov = box('moov', ...tracks.map((spec, index) => trackBox(index + 1, spec)));
+    return concat(ftyp, moov, box('mdat', new Uint8Array(8)));
+  }
+
+  // A metadata sample entry is not an AudioSampleEntry, and may be shorter than one
+  for (const entrySize of [16, 18, 24, 34, 36]) {
+    it(`parses a metadata sample entry of ${entrySize} bytes`, async () => {
+
+      const buf = mp4(videoTrack, {handler: 'meta', dataFormat: 'djmd', entrySize});
+
+      const {format} = await mm.parseBuffer(buf, {mimeType: 'video/mp4'});
+
+      assert.strictEqual(format.hasVideo, true, 'format.hasVideo');
+      assert.isUndefined(format.numberOfChannels, 'format.numberOfChannels');
+    });
+  }
+
+  it('does not derive audio properties from a metadata track', async () => {
+
+    const buf = mp4(videoTrack, {handler: 'meta', dataFormat: 'djmd', entrySize: 36, audioLike: true});
+
+    const {format} = await mm.parseBuffer(buf, {mimeType: 'video/mp4'});
+
+    assert.isUndefined(format.numberOfChannels, 'format.numberOfChannels');
+    assert.isUndefined(format.sampleRate, 'format.sampleRate');
+    assert.isUndefined(format.bitsPerSample, 'format.bitsPerSample');
+    assert.isUndefined(format.trackInfo[1].audio, 'metadata track is not described as audio');
+  });
+
+  it('derives audio properties from a sound track', async () => {
+
+    const buf = mp4(videoTrack, {handler: 'soun', dataFormat: 'mp4a', entrySize: 36, audioLike: true});
+
+    const {format} = await mm.parseBuffer(buf, {mimeType: 'video/mp4'});
+
+    assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
+    assert.strictEqual(format.sampleRate, timeScale, 'format.sampleRate');
+    assert.strictEqual(format.bitsPerSample, 16, 'format.bitsPerSample');
+  });
+
+  it('reports the data format of a non-audio track', async () => {
+
+    const buf = mp4(videoTrack, {handler: 'meta', dataFormat: 'djmd', entrySize: 20});
+
+    const {format} = await mm.parseBuffer(buf, {mimeType: 'video/mp4'});
+
+    assert.strictEqual(format.trackInfo[0].codecName, '<avc1>', 'video track codec name');
+    assert.strictEqual(format.trackInfo[1].codecName, '<djmd>', 'metadata track codec name');
+  });
+
+  it('handles the handler box declared after the media information box', async () => {
+
+    const buf = mp4(videoTrack, {handler: 'soun', dataFormat: 'mp4a', entrySize: 36, audioLike: true, handlerAfterMinf: true});
+
+    const {format} = await mm.parseBuffer(buf, {mimeType: 'video/mp4'});
+
+    assert.strictEqual(format.numberOfChannels, 2, 'format.numberOfChannels');
+    assert.strictEqual(format.sampleRate, timeScale, 'format.sampleRate');
+  });
+
+});

--- a/test/test-trackinfo.ts
+++ b/test/test-trackinfo.ts
@@ -256,13 +256,8 @@ describe('format.trackInfo', () => {
             type: TrackType.audio
           },
           {
-            audio: {
-              bitDepth: 0,
-              channels: 0,
-              samplingFrequency: 1916.1076
-            },
-            codecName: '<avc1>',
-            type: TrackType.audio
+            // A video track holds a VisualSampleEntry, so no audio properties are derived from it
+            codecName: '<avc1>'
           },
           {
             audio: {


### PR DESCRIPTION
Resolves #2690.

Fixes the `RangeError: Offset is outside the bounds of the DataView` thrown while parsing an MP4 `stsd` box, and the type confusion underneath it.

Independent of #2693, which fixes a separate defect in the same box; either can merge first.

## The defect

Sample entries in a sample description box are **track-type specific**, selected by the handler type of the enclosing track. ISO/IEC 14496-12, 8.5.2 states this as a literal switch:

```
aligned(8) class SampleDescriptionBox (unsigned int(32) handler_type)
extends FullBox('stsd', 0, 0){
  unsigned int(32) entry_count;
  for (i = 1 ; i <= entry_count ; i++){
    switch (handler_type){
      case 'soun': AudioSampleEntry();     break;
      case 'vide': VisualSampleEntry();    break;
      case 'hint': HintSampleEntry();      break;
      case 'meta': MetadataSampleEntry();  break;
    }
  }
}
```

`MP4Parser` implements no such switch — it applied `parseSoundSampleDescription` to every entry unconditionally. Two consequences follow.

**1. A crash on short entries.** A `MetaDataSampleEntry` is `extends SampleEntry (codingname) { }` — an empty body, so it may be no larger than the 16-byte `SampleEntry` base. A sound sample description needs 20 bytes beyond that base (`SoundSampleDescriptionVersion.len` 8 + `SoundSampleDescriptionV0.len` 12), so reading one overruns:

| `descrLen` | Result on `master` |
|---|---|
| 0 | OK — the only case #2340 fixed |
| **1–7** | Throws in `SoundSampleDescriptionVersion` (needs 8) |
| **8–19** | Throws in `SoundSampleDescriptionV0` (12 bytes at offset 8 → needs 20) |
| ≥20 | OK |

That is a declared entry size of **17–35 bytes**, with two distinct overrun points. #2338 reported this crash and #2340 fixed only the empty-description case — its test is named *"Handle empty sample entry description"*. It reproduces on ordinary DJI drone footage, which writes `djmd` (telemetry) and `dbgi` (debug) metadata tracks with 20-byte sample entries.

**2. Silent misclassification of larger entries.** Entries of 36 bytes or more never threw, but were still decoded as audio. This is visible in this repository's own corpus — `test/samples/mp4/Mr. Pickles S02E07 My Dear Boy.mp4` has an `avc1` **video** track that `master` reports as an audio stream:

```
BEFORE                                    AFTER
MPEG-4/AAC   AUDIO 2ch 16bit 48000Hz      MPEG-4/AAC   AUDIO 2ch 16bit 48000Hz
<avc1>       AUDIO 0ch 0bit 1916.1076Hz   <avc1>       (not audio)
AC-3         AUDIO 2ch 16bit 48000Hz      AC-3         AUDIO 2ch 16bit 48000Hz
CEA-608      (not audio)                  CEA-608      (not audio)
```

`1916.1076 Hz` is not a sampling frequency — it is the **video's resolution**. `SoundSampleDescriptionV0` computes `sampleRate` as `UINT16_BE(off + 8) + UINT16_BE(off + 10) / 10000`, which lands on entry offsets 32 and 34. In a `VisualSampleEntry` those are `width` and `height`. That track is **1916 × 1076**, giving `1916 + 1076/10000`.

The overlay also explains why the parser did not bail out: entry offset 16 is `pre_defined = 0` in a `VisualSampleEntry`, which decodes as `version = 0` and satisfies `version === 0 || version === 1`. Offsets 24 and 26, read as channel count and sample size, fall inside `unsigned int(32)[3] pre_defined = 0`, hence the `0ch 0bit`.

## The change

Audio properties are now derived only from a track whose handler is `soun` (or `audi`).

- The handler is resolved during **post-processing**, so no box order is assumed. 8.5.2 notes that *"readers should be prepared to accept any box order"*, and `hdlr` sits in `mdia` while `stsd` is deeper in `minf > stbl` — gating at parse time would have relied on an ordering the specification does not guarantee.
- The **entry table is still built for every track**, so `dataFormat` continues to supply `trackInfo.codecName` and `format.codec` for non-audio tracks. Skipping non-audio tracks outright would have regressed codec reporting.
- Where no `hdlr` is present, the previous sample-description heuristic still applies, so those files behave as before.
- Both reads are additionally bounds-checked against the description length, so a genuinely **truncated audio** entry is skipped with a `debug()` warning rather than throwing.

## Tests

`test/test-file-mp4.ts` gains a `Sample Description (stsd) atom` suite that builds its fixtures in memory rather than adding binary samples, as the existing `TrackHeaderAtom` tests do.

Metadata entries of 16, 18, 24, 34 and 36 bytes all parse; a metadata track contributes no audio properties even when its bytes are filled with plausible audio values; a `soun` track still yields them; a non-audio track still reports its data format; and a `trak` with `hdlr` declared **after** `minf` behaves identically, covering the box-order requirement.

The five cases covering the defect were confirmed to **fail against `master`** before the fix; the remaining four passed throughout as controls, showing the fixtures themselves are valid.

`test/test-trackinfo.ts` is amended: the expectation for `Mr. Pickles S02E07 My Dear Boy.mp4` asserted the `avc1` track was `TrackType.audio` with 0 channels and 1916.1076 Hz. That expectation recorded the defect, so it is updated to expect a codec name only.

## Verification

`yarn test` — 595 passing, 1 pending, 0 failing. `yarn typecheck` clean. `yarn lint:ts` exits 0 (7 warnings, all pre-existing on `master`, none in the changed files).

Not run: `yarn build` and `yarn lint:md`.



