### PR TITLE
fix(mp4): locate each sample entry after the first correctly

### DIFF
--- a/lib/mp4/AtomToken.ts
+++ b/lib/mp4/AtomToken.ts
@@ -629,7 +629,8 @@ export class StsdAtom implements IGetToken<IAtomStsd> {
       const size = Token.UINT32_BE.get(buf, off); // Sample description size
       off += Token.UINT32_BE.len;
       table.push(new SampleDescriptionTable(size - Token.UINT32_BE.len).get(buf, off));
-      off += size;
+      // A SampleEntry extends Box, so its size covers the size field already stepped over
+      off += size - Token.UINT32_BE.len;
     }
 
     return {

--- a/test/test-file-mp4.ts
+++ b/test/test-file-mp4.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs';
 import * as mm from '../lib/index.js';
 import { Parsers } from './metadata-parsers.js';
 import { samplePath } from './util.js';
-import { TrackHeaderAtom } from '../lib/mp4/AtomToken.js';
+import { StsdAtom, TrackHeaderAtom } from '../lib/mp4/AtomToken.js';
 
 const mp4Samples = path.join(samplePath, 'mp4');
 
@@ -601,6 +601,63 @@ describe('Parse MPEG-4 files with iTunes metadata', () => {
     assert.approximately(format.duration, 4, 1 / 1000, 'format.duration');
     assert.strictEqual(format.hasAudio, true, 'format.hasAudio');
     assert.strictEqual(format.hasVideo, false, 'format.hasVideo');
+  });
+
+});
+
+describe('Sample Description (stsd) atom: entry table', () => {
+
+  const textEncoder = new TextEncoder();
+
+  /**
+   * A sample entry: 32-bit size, 4-character data format, 6 reserved bytes and the data reference index.
+   * A SampleEntry extends Box, so the size covers the size field itself.
+   *
+   * Ref: ISO/IEC 14496-12, 8.5.2
+   */
+  function sampleEntry(dataFormat: string, size: number, dataReferenceIndex: number): Uint8Array {
+    const entry = new Uint8Array(size);
+    const view = new DataView(entry.buffer);
+    view.setUint32(0, size);
+    entry.set(textEncoder.encode(dataFormat), 4);
+    view.setUint16(14, dataReferenceIndex);
+    return entry;
+  }
+
+  function sampleDescription(...entries: Uint8Array[]): Uint8Array {
+    const buf = new Uint8Array(8 + entries.reduce((total, entry) => total + entry.length, 0));
+    new DataView(buf.buffer).setUint32(4, entries.length); // entry_count
+    let offset = 8;
+    for (const entry of entries) {
+      buf.set(entry, offset);
+      offset += entry.length;
+    }
+    return buf;
+  }
+
+  it('reads a single sample entry', () => {
+    const buf = sampleDescription(sampleEntry('mp4a', 36, 1));
+
+    const {header, table} = new StsdAtom(buf.length).get(buf, 0);
+
+    assert.strictEqual(header.numberOfEntries, 1, 'numberOfEntries');
+    assert.deepEqual(table.map(entry => entry.dataFormat), ['mp4a'], 'dataFormat');
+  });
+
+  // Each entry is located from the size of the one before it, so an error in that arithmetic
+  // only shows up from the second entry onwards
+  it('reads every entry of a table holding more than one, of differing sizes', () => {
+    const buf = sampleDescription(
+      sampleEntry('mp4a', 36, 1),
+      sampleEntry('ac-3', 48, 2),
+      sampleEntry('alac', 20, 3)
+    );
+
+    const {header, table} = new StsdAtom(buf.length).get(buf, 0);
+
+    assert.strictEqual(header.numberOfEntries, 3, 'numberOfEntries');
+    assert.deepEqual(table.map(entry => entry.dataFormat), ['mp4a', 'ac-3', 'alac'], 'dataFormat');
+    assert.deepEqual(table.map(entry => entry.dataReferenceIndex), [1, 2, 3], 'dataReferenceIndex');
   });
 
 });


### PR DESCRIPTION
Resolves #2691.

Independent of #2692, which fixes a separate defect in the same box; either can merge first.

## The defect

`StsdAtom.get` locates each sample entry from the size of the one before it:

```js
const size = Token.UINT32_BE.get(buf, off);  // size field at entry start
off += Token.UINT32_BE.len;                  // off = entryStart + 4
table.push(new SampleDescriptionTable(size - Token.UINT32_BE.len).get(buf, off));
off += size;                                 // off = entryStart + size + 4
```

A `SampleEntry` is `extends Box(format)`, and a box's `size` includes its own 4-byte size field, so the next entry begins at `entryStart + size`. The loop has already stepped over that field, then adds the full `size` — overshooting by 4 bytes, compounding per entry.

The preceding line is consistent with that reading: `SampleDescriptionTable` is constructed with `size - Token.UINT32_BE.len`, the length *excluding* the size field, and reads `data_reference_index` at `off + 10` relative to `entryStart + 4`. #2340 corrected that length but left the cursor advance unchanged, so the two lines currently disagree.

The first entry is unaffected, which is why this has gone unnoticed — no existing test sample declares more than one entry. From the second entry onwards the data format is read from the reserved bytes, giving an all-zero FourCC:

```
FieldDecodingError: FourCC contains invalid characters: 00 00 00 00 "    "
```

Multiple sample entries are legal — several codec configurations on one track, including the clear/encrypted entry pairs common in CMAF.

## The change

```js
// A SampleEntry extends Box, so its size covers the size field already stepped over
off += size - Token.UINT32_BE.len;
```

## Tests

Two tests against `StsdAtom` directly, added next to the existing `Track Header (tkhd) atom` tests and following the same style. `reads a single sample entry` covers the case that works today, so the fixture itself is shown to be sound; `reads every entry of a table holding more than one, of differing sizes` covers the defect, using three entries of 36, 48 and 20 bytes so the arithmetic cannot pass by coincidence, and asserts both the data formats and the data reference indices.

The second test was confirmed to fail on `master` and pass with this change, while the first passes throughout.

## Verification

`yarn test` — 588 passing, 1 pending, 0 failing. `yarn typecheck` clean. `yarn lint:ts` exits 0 (7 warnings, all pre-existing on `master`, none in the changed files).

Not run: `yarn build` and `yarn lint:md`.

