### PR TITLE
Fix DSF parsing of malformed chunk sizes.

### DIFF
--- a/lib/dsf/DsfChunk.ts
+++ b/lib/dsf/DsfChunk.ts
@@ -55,8 +55,8 @@ export const DsdChunk: IGetToken<IDsdChunk> = {
 
   get: (buf: Uint8Array, off: number): IDsdChunk => {
     return {
-      fileSize: Token.INT64_LE.get(buf, off),
-      metadataPointer: Token.INT64_LE.get(buf, off + 8)
+      fileSize: Token.UINT64_LE.get(buf, off),
+      metadataPointer: Token.UINT64_LE.get(buf, off + 8)
     };
   }
 };

--- a/lib/dsf/DsfParser.ts
+++ b/lib/dsf/DsfParser.ts
@@ -1,13 +1,21 @@
 import initDebug from 'debug';
 
 import { AbstractID3Parser } from '../id3v2/AbstractID3Parser.js';
-import { ChunkHeader, DsdChunk, FormatChunk, type IChunkHeader, type IDsdChunk, type IFormatChunk } from './DsfChunk.js';
-import { ID3v2Parser } from "../id3v2/ID3v2Parser.js";
+import {
+  ChunkHeader,
+  DsdChunk,
+  FormatChunk,
+  type IChunkHeader,
+  type IDsdChunk,
+  type IFormatChunk
+} from './DsfChunk.js';
+import { ID3v2Parser } from '../id3v2/ID3v2Parser.js';
 import { makeUnexpectedFileContentError } from '../ParseError.js';
+import { ID3v2Header } from '../id3v2/ID3v2Token.js';
 
 const debug = initDebug('music-metadata:parser:DSF');
 
-export class DsdContentParseError extends makeUnexpectedFileContentError('DSD'){
+export class DsdContentParseError extends makeUnexpectedFileContentError('DSD') {
 }
 
 /**
@@ -20,42 +28,112 @@ export class DsfParser extends AbstractID3Parser {
 
     const p0 = this.tokenizer.position; // mark start position, normally 0
     const chunkHeader = await this.tokenizer.readToken<IChunkHeader>(ChunkHeader);
-    if (chunkHeader.id !== 'DSD ') throw new DsdContentParseError('Invalid chunk signature');
+
+    if (chunkHeader.id !== 'DSD ') {
+      throw new DsdContentParseError('Invalid chunk signature');
+    }
+
+    if (chunkHeader.size !== BigInt(ChunkHeader.len + DsdChunk.len)) {
+      throw new DsdContentParseError(`Invalid DSD chunk size: ${chunkHeader.size}`);
+    }
+
     this.metadata.setFormat('container', 'DSF');
     this.metadata.setFormat('lossless', true);
     this.metadata.setAudioOnly();
+
     const dsdChunk = await this.tokenizer.readToken<IDsdChunk>(DsdChunk);
-    if (dsdChunk.metadataPointer === BigInt(0)) {
-      debug("No ID3v2 tag present");
-    } else {
-      debug(`expect ID3v2 at offset=${dsdChunk.metadataPointer}`);
-      await this.parseChunks(dsdChunk.fileSize - chunkHeader.size);
-      // Jump to ID3 header
-      await this.tokenizer.ignore(Number(dsdChunk.metadataPointer) - this.tokenizer.position - p0);
-      return new ID3v2Parser().parse(this.metadata, this.tokenizer, this.options);
+
+    if (dsdChunk.fileSize < chunkHeader.size) {
+      throw new DsdContentParseError(`Invalid DSF file size: ${dsdChunk.fileSize}`);
     }
+
+    await this.parseChunks(dsdChunk.fileSize - chunkHeader.size);
+
+    if (dsdChunk.metadataPointer === 0n) {
+      debug('No ID3v2 tag present');
+      return;
+    }
+
+    debug(`expect ID3v2 at offset=${dsdChunk.metadataPointer}`);
+
+    const metadataOffset =
+      dsdChunk.metadataPointer - BigInt(this.tokenizer.position - p0);
+
+    if (
+      metadataOffset < 0n ||
+      metadataOffset > BigInt(Number.MAX_SAFE_INTEGER) ||
+      dsdChunk.metadataPointer + BigInt(ID3v2Header.len) > dsdChunk.fileSize
+    ) {
+      throw new DsdContentParseError(`Invalid metadata pointer: ${dsdChunk.metadataPointer}`);
+    }
+
+    await this.tokenizer.ignore(Number(metadataOffset));
+
+    return new ID3v2Parser().parse(
+      this.metadata,
+      this.tokenizer,
+      this.options
+    );
   }
 
-  private async parseChunks(bytesRemaining: bigint) {
-    while (bytesRemaining >= ChunkHeader.len) {
+  private async parseChunks(bytesRemaining: bigint): Promise<void> {
+
+    const chunkHeaderSize = BigInt(ChunkHeader.len);
+
+    while (bytesRemaining >= chunkHeaderSize) {
       const chunkHeader = await this.tokenizer.readToken<IChunkHeader>(ChunkHeader);
+
       debug(`Parsing chunk name=${chunkHeader.id} size=${chunkHeader.size}`);
+
+      if (chunkHeader.size < chunkHeaderSize) {
+        throw new DsdContentParseError(
+          `Invalid ${chunkHeader.id} chunk size: ${chunkHeader.size}`
+        );
+      }
+
+      if (chunkHeader.size > bytesRemaining) {
+        throw new DsdContentParseError(
+          `${chunkHeader.id} chunk exceeds remaining file size`
+        );
+      }
+
+      const payloadSize = chunkHeader.size - chunkHeaderSize;
+
       switch (chunkHeader.id) {
+
         case 'fmt ': {
+          if (payloadSize < BigInt(FormatChunk.len)) {
+            throw new DsdContentParseError(
+              `Invalid fmt chunk size: ${chunkHeader.size}`
+            );
+          }
+
           const formatChunk = await this.tokenizer.readToken<IFormatChunk>(FormatChunk);
+
           this.metadata.setFormat('numberOfChannels', formatChunk.channelNum);
           this.metadata.setFormat('sampleRate', formatChunk.samplingFrequency);
           this.metadata.setFormat('bitsPerSample', formatChunk.bitsPerSample);
           this.metadata.setFormat('numberOfSamples', formatChunk.sampleCount);
-          this.metadata.setFormat('duration', Number(formatChunk.sampleCount) / formatChunk.samplingFrequency);
-          const bitrate = formatChunk.bitsPerSample * formatChunk.samplingFrequency * formatChunk.channelNum;
+          this.metadata.setFormat(
+            'duration',
+            Number(formatChunk.sampleCount) / formatChunk.samplingFrequency
+          );
+
+          const bitrate =
+            formatChunk.bitsPerSample *
+            formatChunk.samplingFrequency *
+            formatChunk.channelNum;
+
           this.metadata.setFormat('bitrate', bitrate);
+
           return; // We got what we want, stop further processing of chunks
         }
+
         default:
-          this.tokenizer.ignore(Number(chunkHeader.size) - ChunkHeader.len);
+          await this.tokenizer.ignore(Number(payloadSize));
           break;
       }
+
       bytesRemaining -= chunkHeader.size;
     }
   }


### PR DESCRIPTION
The DSF parser skipped unknown chunk payloads using an un-awaited tokenizer.ignore() call. When a malformed chunk declared a size smaller than the chunk header, this resulted in a negative skip length. strtok3 rejects such calls, and because the promise was not awaited, the rejection could escape the parser promise chain and terminate the Node.js process as an unhandled rejection.

Changes:
- Await tokenizer.ignore() when skipping unknown DSF chunks.
- Validate chunk sizes before processing or skipping their payload.
- Reject chunks that exceed the remaining DSF data.
- Validate the minimum size of the fmt chunk.
- Validate the DSF metadata pointer before seeking to the ID3v2 tag.
- Parse the fmt chunk independently of the presence of an ID3v2 tag.