### PR TITLE
Fix ASF header extension data size parsing

### DIFF
--- a/lib/asf/AsfObject.ts
+++ b/lib/asf/AsfObject.ts
@@ -323,7 +323,7 @@ export class HeaderExtensionObject implements IGetToken<IHeaderExtensionObject> 
     return {
       reserved1: AsfGuid.fromBin(buf, off),
       reserved2: view.getUint16(16, true),
-      extensionDataSize: view.getUint16(18, true)
+      extensionDataSize: view.getUint32(18, true)
     };
   }
 }

--- a/test/test-file-asf.ts
+++ b/test/test-file-asf.ts
@@ -3,7 +3,7 @@ import * as mm from '../lib/index.js';
 import path from 'node:path';
 import AsfGuid from '../lib/asf/AsfGuid.js';
 import { getParserForAttr } from '../lib/asf/AsfUtil.js';
-import { AsfContentParseError, DataType } from '../lib/asf/AsfObject.js';
+import { AsfContentParseError, DataType, HeaderExtensionObject } from '../lib/asf/AsfObject.js';
 import { Parsers } from './metadata-parsers.js';
 
 import { samplePath } from './util.js';
@@ -29,6 +29,13 @@ describe('Parse ASF', () => {
       const guid_data = new Uint8Array([48, 38, 178, 117, 142, 102, 207, 17, 166, 217, 0, 170, 0, 98, 206, 108]);
       assert.deepEqual(AsfGuid.fromBin(guid_data).str, '75B22630-668E-11CF-A6D9-00AA0062CE6C');
     });
+  });
+
+  it('reads the 32-bit header extension data size', () => {
+    const extensionHeader = new Uint8Array(22);
+    new DataView(extensionHeader.buffer).setUint32(18, 98547, true);
+
+    expect(new HeaderExtensionObject().get(extensionHeader, 0).extensionDataSize).to.equal(98547);
   });
 
   /**


### PR DESCRIPTION
## Summary

Fix ASF Header Extension Object parsing by reading `extensionDataSize` as a 32-bit value, as defined by the ASF specification.

Previously, the field was read as 16-bit, causing values above `65,535` to be truncated. For example, an extension size of `98,547` was interpreted as `33,011`, which could cause valid WMA/ASF files to be parsed incorrectly.

## Changes

- Read `extensionDataSize` using `getUint32`.
- Add a regression test covering a value larger than the 16-bit range.

## Validation

- TypeScript typecheck passes.
- Regression check confirms `98,547` is parsed without truncation.