### PR TITLE
Switch coveralls to secret-less codecov

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -3,6 +3,11 @@
     "lcov",
     "text"
   ],
-  "include": ["lib/**"],
-  "exclude": [".yarn/**"]
+  "all": true,
+  "check-coverage": true,
+  "lines": 1,
+  "extension": [".ts"],
+  "include": ["lib/**/*.ts"],
+  "exclude": ["lib/**/*.d.ts"],
+  "exclude-after-remap": true
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,14 +81,47 @@ jobs:
           name: build
 
       - name: Test with Node.js ${{ matrix.node-version }}
+        run: yarn run test
+
+  coverage:
+    name: Test coverage
+    runs-on: ubuntu-latest
+
+    needs: build
+
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      YARN_IGNORE_NODE: 1
+
+    steps:
+
+      - name: 'Checkout the repository'
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.x
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Generate coverage from TypeScript sources
         run: yarn run test-coverage
 
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@v2
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.test_number }}
-          parallel: true
+          files: ./coverage/lcov.info
+          disable_search: true
+          fail_ci_if_error: true
+          use_oidc: true
 
   test-bun:
     name: Test with Bun
@@ -120,13 +153,3 @@ jobs:
 
       - name: Test with Node.js ${{ matrix.node-version }}
         run: bun run --bun test
-
-  finish:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.github_token }}
-          parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI](https://github.com/Borewit/music-metadata/actions/workflows/ci.yml/badge.svg)](https://github.com/Borewit/music-metadata/actions/workflows/ci.yml)
 [![NPM version](https://img.shields.io/npm/v/music-metadata.svg)](https://npmjs.org/package/music-metadata)
 [![npm downloads](http://img.shields.io/npm/dm/music-metadata.svg)](https://npmcharts.com/compare/music-metadata?start=600&interval=7)
-[![Coverage Status](https://coveralls.io/repos/github/Borewit/music-metadata/badge.svg?branch=master)](https://coveralls.io/github/Borewit/music-metadata?branch=master)
+[![codecov](https://codecov.io/gh/Borewit/music-metadata/branch/master/graph/badge.svg)](https://codecov.io/gh/Borewit/music-metadata)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/57d731b05c9e41889a2a17cb4b0384d7)](https://app.codacy.com/app/Borewit/music-metadata?utm_source=github.com&utm_medium=referral&utm_content=Borewit/music-metadata&utm_campaign=Badge_Grade_Dashboard)
 [![CodeQL](https://github.com/Borewit/music-metadata/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Borewit/music-metadata/actions/workflows/codeql-analysis.yml)
 [![DeepScan grade](https://deepscan.io/api/teams/5165/projects/6938/branches/61821/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=5165&pid=6938&bid=61821)


### PR DESCRIPTION
Replaces Coveralls with secretless Codecov coverage reporting.

### Changes:
- Adds a dedicated OIDC-authenticated coverage job.
- Updates c8 TypeScript coverage configuration.
- Replaces the README coverage badge